### PR TITLE
Update Spice SDK installation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Rust SDK for Spice.ai
 
 ## Installation
 
-Add `spiceai` crate:
+Add Spice SDK
 
 ```bash
 cargo add spiceai

--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@ Rust SDK for Spice.ai
 
 ## Installation
 
-Add the following to your `Cargo.toml`:
+Add `spiceai` crate:
 
-```toml
-[dependencies]
-spice-rs = { git = "https://github.com/spiceai/spice-rs", tag = "v1.0.2" }
+```bash
+cargo add spiceai
 ```
 
 ## Usage


### PR DESCRIPTION
Spice Rust SDK was renamed from`spice-rs` to `spiceai` and is now distributed via https://crates.io/crates/spiceai