### PR TITLE
Update arrow and arrow-flight to 51.0.0, and tonic to 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,14 @@ description = "SDK for Spice.ai, an open-source runtime and platform for buildin
 license = "Apache-2.0"
 
 [dependencies]
-arrow-flight = { version = "49.0.0", features = ["flight-sql-experimental"] }
+arrow-flight = { version = "51.0.0", features = ["flight-sql-experimental"] }
 bytes = "1.6.0"
 prost = "0.12.4"
 prost-types = "0.12.4"
 rustls = "0.23.5"
 tokio = "1.37.0"
 rustls-native-certs = "0.6.3"
-tonic = { version = "0.10.0", default-features = false, features = [
+tonic = { version = "0.11.0", default-features = false, features = [
   "transport",
   "tls",
   "tls-roots",
@@ -24,6 +24,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.116"
 chrono = { version = "0.4.38", features = ["serde"] }
 dotenv = "0.15.0"
-arrow = "49.0.0"
+arrow = "51.0.0"
 futures = "0.3.30"
 base64 = "0.22.0"


### PR DESCRIPTION
Update dependencies: 
- `arrow-flight`: 49.0.0 → 51.0.0
- `arrow`: 49.0.0 → 51.0.0
- `tonic`: 0.10.0 → 0.11.0