### PR TITLE
Use proper grpc protocol for flight address in config and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ use spiceai::ClientBuilder;
 #[tokio::main]
 async fn main() {
   let mut client = ClientBuilder::new()
-    .flight_url("http://localhost:50051")
+    .flight_url("grpc://localhost:50051")
     .build()
     .await
     .unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,4 +2,4 @@ pub const SPICE_CLOUD_FLIGHT_ADDR: &str = "https://flight.spiceai.io";
 pub const SPICE_CLOUD_FIRECACHE_ADDR: &str = "https://firecache.spiceai.io";
 
 // default address for local spice runtime
-pub const SPICE_LOCAL_FLIGHT_ADDR: &str = "http://localhost:50051";
+pub const SPICE_LOCAL_FLIGHT_ADDR: &str = "grpc://localhost:50051";


### PR DESCRIPTION
- **Update arrow and arrow-flight to 51.0.0, and tonic to 0.11.0**
- **Use proper grpc protocol for flight address in config and readme**
