### PR TITLE
Support query retry, parameterized query, and cache control header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "1.6.0"
 prost = "0.12.4"
 prost-types = "0.12.4"
 rustls = "0.23.5"
-tokio = "1.37.0"
+tokio = { version = "1.37.0", features = ["signal"] }
 rustls-native-certs = "0.6.3"
 tonic = { version = "0.12.3", default-features = false, features = [
   "transport",
@@ -28,7 +28,9 @@ arrow = "55.1.0"
 futures = "0.3.31"
 base64 = "0.22.0"
 tracing = "0.1.41"
-spice-util = { git = "https://github.com/spiceai/spiceai", package = "util" }
+backoff = { version = "0.4.0", features = ["futures", "tokio"] }
+rand = "0.9.1"
+
 
 [target.'cfg(windows)'.dependencies]
 winver = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ dotenv = "0.15.0"
 arrow = "55.1.0"
 futures = "0.3.31"
 base64 = "0.22.0"
+tracing = "0.1.41"
+spice-util = { git = "https://github.com/spiceai/spiceai", package = "util" }
 
 [target.'cfg(windows)'.dependencies]
 winver = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ prost = "0.12.4"
 prost-types = "0.12.4"
 rustls = "0.23.5"
 tokio = { version = "1.37.0", features = ["signal"] }
-rustls-native-certs = "0.6.3"
+rustls-native-certs = "0.8.1"
 tonic = { version = "0.12.3", default-features = false, features = [
   "transport",
   "tls",
@@ -24,7 +24,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.116"
 chrono = { version = "0.4.41", features = ["serde"] }
 dotenv = "0.15.0"
-arrow = "55.1.0"
+arrow = { version = "55.1.0", features = ["prettyprint"] }
 futures = "0.3.31"
 base64 = "0.22.0"
 tracing = "0.1.41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,14 @@ description = "SDK for Spice.ai, an open-source runtime and platform for buildin
 license = "Apache-2.0"
 
 [dependencies]
-arrow-flight = { version = "51.0.0", features = ["flight-sql-experimental"] }
+arrow-flight = { version = "55.1.0", features = ["flight-sql-experimental"] }
 bytes = "1.6.0"
 prost = "0.12.4"
 prost-types = "0.12.4"
 rustls = "0.23.5"
 tokio = "1.37.0"
 rustls-native-certs = "0.6.3"
-tonic = { version = "0.11.0", default-features = false, features = [
+tonic = { version = "0.12.3", default-features = false, features = [
   "transport",
   "tls",
   "tls-roots",
@@ -22,10 +22,10 @@ rustls-pemfile = "1.0.4"
 reqwest = { version = "0.12.4", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.116"
-chrono = { version = "0.4.38", features = ["serde"] }
+chrono = { version = "0.4.41", features = ["serde"] }
 dotenv = "0.15.0"
-arrow = "51.0.0"
-futures = "0.3.30"
+arrow = "55.1.0"
+futures = "0.3.31"
 base64 = "0.22.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ use spiceai::ClientBuilder;
 
 #[tokio::main]
 async fn main() {
-  let mut client = ClientBuilder::new()
+  let client = ClientBuilder::new()
     .flight_url("http://localhost:50051")
     .build()
     .await
@@ -40,7 +40,7 @@ use spiceai::ClientBuilder;
 
 #[tokio::main]
 async fn main() {
-  let mut client = ClientBuilder::new()
+  let client = ClientBuilder::new()
     .api_key("API_KEY")
     .use_spiceai_cloud()
     .build()
@@ -58,7 +58,7 @@ use spiceai::ClientBuilder;
 
 #[tokio::main]
 async fn main() {
-  let mut client = ClientBuilder::new()
+  let client = ClientBuilder::new()
     .api_key("API_KEY")
     .use_spiceai_cloud()
     .build()

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,9 +5,10 @@ use crate::{
 };
 use arrow::record_batch::RecordBatch;
 use arrow_flight::decode::FlightRecordBatchStream;
+use spice_util::{fibonacci_backoff::FibonacciBackoffBuilder, retry, RetryError};
 use tonic::transport::Channel;
 
-const MAX_RETRIES: u32 = 5;
+const MAX_RETRIES: usize = 5;
 
 struct SpiceClientConfig {
     flight_channel: Channel,
@@ -79,33 +80,23 @@ impl SpiceClient {
     ///
     /// - `Box<dyn Error + Send + Sync>` for any query error
     pub async fn query(&self, query: &str) -> Result<FlightRecordBatchStream, GenericError> {
-        let mut retry_count = 0;
+        let retry_strategy = FibonacciBackoffBuilder::new()
+            .max_retries(Some(MAX_RETRIES))
+            .build();
 
-        loop {
+        retry(retry_strategy, || async {
             match self.flight.query(query).await {
-                Ok(stream) => return Ok(stream),
+                Ok(stream) => Ok(stream),
                 Err(e) => {
-                    let error_str = e.to_string();
-
-                    if retry_count < MAX_RETRIES && is_retryable_error(&error_str) {
-                        retry_count += 1;
-                        eprintln!(
-                            "Connection error on query attempt {retry_count}/{MAX_RETRIES}: {e}. Retrying..."
-                        );
-
-                        // Exponential backoff
-                        tokio::time::sleep(std::time::Duration::from_millis(
-                            100 * (1 << retry_count),
-                        ))
-                        .await;
-
-                        continue;
+                    if is_retryable_error(&e.to_string()) {
+                        Err(RetryError::transient(e))
+                    } else {
+                        Err(RetryError::permanent(e))
                     }
-
-                    return Err(e);
                 }
             }
-        }
+        })
+        .await
     }
 
     /// Optional parameterized query with the Spice Flight endpoint with the given SQL query.
@@ -130,33 +121,23 @@ impl SpiceClient {
         query: &str,
         params: Option<RecordBatch>,
     ) -> Result<FlightRecordBatchStream, GenericError> {
-        let mut retry_count = 0;
+        let retry_strategy = FibonacciBackoffBuilder::new()
+            .max_retries(Some(MAX_RETRIES))
+            .build();
 
-        loop {
+        retry(retry_strategy, || async {
             match self.flight.query_with_params(query, params.clone()).await {
-                Ok(stream) => return Ok(stream),
+                Ok(stream) => Ok(stream),
                 Err(e) => {
-                    let error_str = e.to_string();
-
-                    if retry_count < MAX_RETRIES && is_retryable_error(&error_str) {
-                        retry_count += 1;
-                        eprintln!(
-                            "Connection error on query attempt {retry_count}/{MAX_RETRIES}: {e}. Retrying..."
-                        );
-
-                        // Exponential backoff
-                        tokio::time::sleep(std::time::Duration::from_millis(
-                            100 * (1 << retry_count),
-                        ))
-                        .await;
-
-                        continue;
+                    if is_retryable_error(&e.to_string()) {
+                        Err(RetryError::transient(e))
+                    } else {
+                        Err(RetryError::permanent(e))
                     }
-
-                    return Err(e);
                 }
             }
-        }
+        })
+        .await
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -149,7 +149,7 @@ fn is_retryable_error(error: &GenericError) -> bool {
     if let Some(status) = error.downcast_ref::<tonic::Status>() {
         return status.metadata().get("spiceai-retryable").is_some();
     }
-    return false;
+    false
 }
 
 fn map_generic_error(error: GenericError) -> GenericError {

--- a/src/client.rs
+++ b/src/client.rs
@@ -78,7 +78,7 @@ impl SpiceClient {
     /// ## Errors
     ///
     /// - `Box<dyn Error + Send + Sync>` for any query error
-    pub async fn query(&mut self, query: &str) -> Result<FlightRecordBatchStream, GenericError> {
+    pub async fn query(&self, query: &str) -> Result<FlightRecordBatchStream, GenericError> {
         let mut retry_count = 0;
 
         loop {
@@ -126,7 +126,7 @@ impl SpiceClient {
     ///
     /// - `Box<dyn Error + Send + Sync>` for any query error
     pub async fn query_with_params(
-        &mut self,
+        &self,
         query: &str,
         params: Option<RecordBatch>,
     ) -> Result<FlightRecordBatchStream, GenericError> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,3 +1,4 @@
+use crate::util::{retry, FibonacciBackoffBuilder, RetryError};
 use crate::{
     config::{GenericError, SPICE_CLOUD_FLIGHT_ADDR, SPICE_LOCAL_FLIGHT_ADDR},
     flight::SqlFlightClient,
@@ -6,7 +7,6 @@ use crate::{
 use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
 use arrow_flight::decode::FlightRecordBatchStream;
-use spice_util::{fibonacci_backoff::FibonacciBackoffBuilder, retry, RetryError};
 use tonic::transport::Channel;
 
 const MAX_RETRIES: usize = 3;

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,6 +3,7 @@ use crate::{
     flight::SqlFlightClient,
     tls::new_tls_flight_channel,
 };
+use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
 use arrow_flight::decode::FlightRecordBatchStream;
 use spice_util::{fibonacci_backoff::FibonacciBackoffBuilder, retry, RetryError};
@@ -88,7 +89,7 @@ impl SpiceClient {
             match self.flight.query(query).await {
                 Ok(stream) => Ok(stream),
                 Err(e) => {
-                    if is_retryable_error(&e.to_string()) {
+                    if is_retryable_error(&e) {
                         Err(RetryError::transient(e))
                     } else {
                         Err(RetryError::permanent(e))
@@ -97,6 +98,7 @@ impl SpiceClient {
             }
         })
         .await
+        .map_err(map_generic_error)
     }
 
     /// Optional parameterized query with the Spice Flight endpoint with the given SQL query.
@@ -129,7 +131,7 @@ impl SpiceClient {
             match self.flight.query_with_params(query, params.clone()).await {
                 Ok(stream) => Ok(stream),
                 Err(e) => {
-                    if is_retryable_error(&e.to_string()) {
+                    if is_retryable_error(&e) {
                         Err(RetryError::transient(e))
                     } else {
                         Err(RetryError::permanent(e))
@@ -138,13 +140,27 @@ impl SpiceClient {
             }
         })
         .await
+        .map_err(map_generic_error)
     }
 }
 
-fn is_retryable_error(error_str: &str) -> bool {
-    error_str
-        .to_lowercase()
-        .contains("connection is reset by the server. please retry the request.")
+fn is_retryable_error(error: &GenericError) -> bool {
+    if let Some(status) = error.downcast_ref::<tonic::Status>() {
+        return status.metadata().get("spiceai-retryable").is_some();
+    }
+    return false;
+}
+
+fn map_generic_error(error: GenericError) -> GenericError {
+    if let Some(status) = error.downcast_ref::<tonic::Status>() {
+        return status_to_arrow_error(status).into();
+    }
+    error
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn status_to_arrow_error(status: &tonic::Status) -> ArrowError {
+    ArrowError::IpcError(format!("{status:?}"))
 }
 
 /// Builder for creating a `SpiceClient`.

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,8 +3,11 @@ use crate::{
     flight::SqlFlightClient,
     tls::new_tls_flight_channel,
 };
+use arrow::record_batch::RecordBatch;
 use arrow_flight::decode::FlightRecordBatchStream;
 use tonic::transport::Channel;
+
+const MAX_RETRIES: u32 = 5;
 
 struct SpiceClientConfig {
     flight_channel: Channel,
@@ -47,7 +50,12 @@ impl SpiceClient {
         let config = SpiceClientConfig::load_from_default().await?;
 
         Ok(Self {
-            flight: SqlFlightClient::new(config.flight_channel, Some(api_key.to_string()), None),
+            flight: SqlFlightClient::new(
+                config.flight_channel,
+                Some(api_key.to_string()),
+                None,
+                None,
+            ),
         })
     }
 
@@ -71,8 +79,91 @@ impl SpiceClient {
     ///
     /// - `Box<dyn Error + Send + Sync>` for any query error
     pub async fn query(&mut self, query: &str) -> Result<FlightRecordBatchStream, GenericError> {
-        self.flight.query(query).await
+        let mut retry_count = 0;
+
+        loop {
+            match self.flight.query(query).await {
+                Ok(stream) => return Ok(stream),
+                Err(e) => {
+                    let error_str = e.to_string();
+
+                    if retry_count < MAX_RETRIES && is_retryable_error(&error_str) {
+                        retry_count += 1;
+                        eprintln!(
+                            "Connection error on query attempt {retry_count}/{MAX_RETRIES}: {e}. Retrying..."
+                        );
+
+                        // Exponential backoff
+                        tokio::time::sleep(std::time::Duration::from_millis(
+                            100 * (1 << retry_count),
+                        ))
+                        .await;
+
+                        continue;
+                    }
+
+                    return Err(e);
+                }
+            }
+        }
     }
+
+    /// Optional parameterized query with the Spice Flight endpoint with the given SQL query.
+    /// /// If `params` is `None`, it behaves like a regular query.
+    /// `params` is a parameter binding `RecordBatch`.
+    /// <https://docs.rs/arrow-flight/latest/arrow_flight/sql/client/struct.PreparedStatement.html#method.set_parameters>
+    /// ```
+    /// # use spiceai::Client;
+    /// #
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// #  let mut client = Client::new("API_KEY").await.unwrap();
+    /// let data = client.query_with_params("SELECT * FROM taxi_trips LIMIT 10;", None).await;
+    /// # }
+    /// ````
+    ///
+    /// ## Errors
+    ///
+    /// - `Box<dyn Error + Send + Sync>` for any query error
+    pub async fn query_with_params(
+        &mut self,
+        query: &str,
+        params: Option<RecordBatch>,
+    ) -> Result<FlightRecordBatchStream, GenericError> {
+        let mut retry_count = 0;
+
+        loop {
+            match self.flight.query_with_params(query, params.clone()).await {
+                Ok(stream) => return Ok(stream),
+                Err(e) => {
+                    let error_str = e.to_string();
+
+                    if retry_count < MAX_RETRIES && is_retryable_error(&error_str) {
+                        retry_count += 1;
+                        eprintln!(
+                            "Connection error on query attempt {retry_count}/{MAX_RETRIES}: {e}. Retrying..."
+                        );
+
+                        // Exponential backoff
+                        tokio::time::sleep(std::time::Duration::from_millis(
+                            100 * (1 << retry_count),
+                        ))
+                        .await;
+
+                        continue;
+                    }
+
+                    return Err(e);
+                }
+            }
+        }
+    }
+}
+
+fn is_retryable_error(error_str: &str) -> bool {
+    error_str
+        .to_lowercase()
+        .contains("connection is reset by the server. please retry the request.")
 }
 
 /// Builder for creating a `SpiceClient`.
@@ -110,6 +201,7 @@ pub struct SpiceClientBuilder {
     api_key: Option<String>,
     user_agent: Option<String>,
     flight_url: Option<String>,
+    cache_control: Option<String>,
 }
 
 impl Default for SpiceClientBuilder {
@@ -125,6 +217,7 @@ impl SpiceClientBuilder {
             api_key: None,
             user_agent: None,
             flight_url: None,
+            cache_control: None,
         }
     }
 
@@ -146,6 +239,13 @@ impl SpiceClientBuilder {
     #[must_use]
     pub fn flight_url(mut self, flight_url: &str) -> Self {
         self.flight_url = Some(flight_url.to_string());
+        self
+    }
+
+    /// Configures the cache control to use the given Spice Flight endpoint.
+    #[must_use]
+    pub fn cache_control(mut self, cache_control: &str) -> Self {
+        self.cache_control = Some(cache_control.to_string());
         self
     }
 
@@ -173,6 +273,7 @@ impl SpiceClientBuilder {
                 flight_channel,
                 self.api_key.clone(),
                 self.user_agent.clone(),
+                self.cache_control.clone(),
             ),
         })
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -30,6 +30,7 @@ impl SpiceClientConfig {
 /// The `SpiceClient` is the main entry point for interacting with the Spice API.
 /// It provides methods for querying the Spice Flight endpoint.
 #[allow(clippy::module_name_repetitions)]
+#[derive(Clone)]
 pub struct SpiceClient {
     flight: SqlFlightClient,
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,7 +9,7 @@ use arrow_flight::decode::FlightRecordBatchStream;
 use spice_util::{fibonacci_backoff::FibonacciBackoffBuilder, retry, RetryError};
 use tonic::transport::Channel;
 
-const MAX_RETRIES: usize = 5;
+const MAX_RETRIES: usize = 3;
 
 struct SpiceClientConfig {
     flight_channel: Channel,
@@ -89,13 +89,7 @@ impl SpiceClient {
         retry(retry_strategy, || async {
             match self.flight.query(query).await {
                 Ok(stream) => Ok(stream),
-                Err(e) => {
-                    if is_retryable_error(&e) {
-                        Err(RetryError::transient(e))
-                    } else {
-                        Err(RetryError::permanent(e))
-                    }
-                }
+                Err(e) => Err(map_retryable_error(e)),
             }
         })
         .await
@@ -131,13 +125,7 @@ impl SpiceClient {
         retry(retry_strategy, || async {
             match self.flight.query_with_params(query, params.clone()).await {
                 Ok(stream) => Ok(stream),
-                Err(e) => {
-                    if is_retryable_error(&e) {
-                        Err(RetryError::transient(e))
-                    } else {
-                        Err(RetryError::permanent(e))
-                    }
-                }
+                Err(e) => Err(map_retryable_error(e)),
             }
         })
         .await
@@ -145,11 +133,13 @@ impl SpiceClient {
     }
 }
 
-fn is_retryable_error(error: &GenericError) -> bool {
+fn map_retryable_error(error: GenericError) -> RetryError<GenericError> {
     if let Some(status) = error.downcast_ref::<tonic::Status>() {
-        return status.metadata().get("spiceai-retryable").is_some();
+        if status.metadata().get("spiceai-retryable").is_some() {
+            return RetryError::transient(error);
+        }
     }
-    false
+    RetryError::permanent(error)
 }
 
 fn map_generic_error(error: GenericError) -> GenericError {
@@ -200,6 +190,7 @@ pub struct SpiceClientBuilder {
     user_agent: Option<String>,
     flight_url: Option<String>,
     cache_control: Option<String>,
+    max_retries: usize,
 }
 
 impl Default for SpiceClientBuilder {
@@ -216,6 +207,7 @@ impl SpiceClientBuilder {
             user_agent: None,
             flight_url: None,
             cache_control: None,
+            max_retries: MAX_RETRIES,
         }
     }
 
@@ -240,7 +232,14 @@ impl SpiceClientBuilder {
         self
     }
 
-    /// Configures the cache control to use the given Spice Flight endpoint.
+    /// Configures the `SpiceClient` to use the given maximum number of retries.
+    #[must_use]
+    pub fn max_retries(mut self, max_retries: usize) -> Self {
+        self.max_retries = max_retries;
+        self
+    }
+
+    /// Configures the cache control to use the given cache control policy.
     #[must_use]
     pub fn cache_control(mut self, cache_control: &str) -> Self {
         self.cache_control = Some(cache_control.to_string());

--- a/src/client.rs
+++ b/src/client.rs
@@ -42,7 +42,7 @@ impl SpiceClient {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let mut client = Client::new("API_KEY").await.unwrap();
+    ///     let client = Client::new("API_KEY").await.unwrap();
     /// }
     /// ```
     ///
@@ -73,7 +73,7 @@ impl SpiceClient {
     /// #
     /// # #[tokio::main]
     /// # async fn main() {
-    /// #  let mut client = Client::new("API_KEY").await.unwrap();
+    /// #  let client = Client::new("API_KEY").await.unwrap();
     /// let data = client.query("SELECT * FROM taxi_trips LIMIT 10;").await;
     /// # }
     /// ````
@@ -105,7 +105,7 @@ impl SpiceClient {
     /// #
     /// # #[tokio::main]
     /// # async fn main() {
-    /// #  let mut client = Client::new("API_KEY").await.unwrap();
+    /// #  let client = Client::new("API_KEY").await.unwrap();
     /// let data = client.query_with_params("SELECT * FROM taxi_trips LIMIT 10;", None).await;
     /// # }
     /// ````
@@ -163,7 +163,7 @@ fn status_to_arrow_error(status: &tonic::Status) -> ArrowError {
 /// #
 /// # #[tokio::main]
 /// # async fn main() {
-/// #    let mut client = ClientBuilder::new()
+/// #    let client = ClientBuilder::new()
 /// #      .build()
 /// #      .await
 /// #      .unwrap();
@@ -176,7 +176,7 @@ fn status_to_arrow_error(status: &tonic::Status) -> ArrowError {
 /// #
 /// # #[tokio::main]
 /// # async fn main() {
-/// #    let mut client = ClientBuilder::new()
+/// #    let client = ClientBuilder::new()
 /// #      .api_key("API_KEY")
 /// #      .use_spiceai_cloud()
 /// #      .build()

--- a/src/flight.rs
+++ b/src/flight.rs
@@ -94,12 +94,7 @@ impl SqlFlightClient {
 
     async fn authenticate(&self) -> std::result::Result<Option<String>, GenericError> {
         let (username, password) = match &self.api_key {
-            Some(api_key) => {
-                if api_key.as_ref().split('|').collect::<String>().len() < 2 {
-                    return Err("Invalid API key format".into());
-                }
-                ("", api_key.as_ref())
-            }
+            Some(api_key) => ("", api_key.as_ref()),
             None => return Ok(None),
         };
 

--- a/src/flight.rs
+++ b/src/flight.rs
@@ -95,7 +95,7 @@ impl SqlFlightClient {
     async fn authenticate(&self) -> std::result::Result<Option<String>, GenericError> {
         let (username, password) = match &self.api_key {
             Some(api_key) => {
-                if api_key.to_string().split('|').collect::<String>().len() < 2 {
+                if api_key.as_ref().split('|').collect::<String>().len() < 2 {
                     return Err("Invalid API key format".into());
                 }
                 ("", api_key.as_ref())

--- a/src/flight.rs
+++ b/src/flight.rs
@@ -25,11 +25,6 @@ pub struct SqlFlightClient {
     api_key: Option<String>,
 }
 
-#[allow(clippy::needless_pass_by_value)]
-fn status_to_arrow_error(status: tonic::Status) -> ArrowError {
-    ArrowError::IpcError(format!("{status:?}"))
-}
-
 impl SqlFlightClient {
     pub fn new(
         chan: Channel,
@@ -143,25 +138,14 @@ impl SqlFlightClient {
         let descriptor = FlightDescriptor::new_cmd(query.to_string());
         let req = self.set_request_headers(descriptor.into_request(), token.clone())?;
 
-        let info = self
-            .client
-            .clone()
-            .get_flight_info(req)
-            .await
-            .map_err(status_to_arrow_error)?
-            .into_inner();
+        let info = self.client.clone().get_flight_info(req).await?.into_inner();
 
         for ep in info.endpoint {
             if let Some(tkt) = ep.ticket {
                 let req = tkt.into_request();
                 let req = self.set_request_headers(req, token.clone())?;
-                let (md, response_stream, _ext) = self
-                    .client
-                    .clone()
-                    .do_get(req)
-                    .await
-                    .map_err(status_to_arrow_error)?
-                    .into_parts();
+                let (md, response_stream, _ext) =
+                    self.client.clone().do_get(req).await?.into_parts();
 
                 return Ok(FlightRecordBatchStream::new_from_flight_data(
                     response_stream.map_err(|e| FlightError::Tonic(Box::new(e))),

--- a/src/flight.rs
+++ b/src/flight.rs
@@ -1,9 +1,11 @@
 use crate::config::get_user_agent;
 use crate::config::GenericError;
 use arrow::error::ArrowError;
+use arrow::record_batch::RecordBatch;
 use arrow_flight::decode::FlightRecordBatchStream;
 use arrow_flight::error::FlightError;
 use arrow_flight::flight_service_client::FlightServiceClient;
+use arrow_flight::sql::client::FlightSqlServiceClient;
 use arrow_flight::FlightDescriptor;
 use arrow_flight::HandshakeRequest;
 use arrow_flight::HandshakeResponse;
@@ -31,7 +33,12 @@ fn status_to_arrow_error(status: tonic::Status) -> ArrowError {
 }
 
 impl SqlFlightClient {
-    pub fn new(chan: Channel, api_key: Option<String>, user_agent: Option<String>) -> Self {
+    pub fn new(
+        chan: Channel,
+        api_key: Option<String>,
+        user_agent: Option<String>,
+        cache_control: Option<String>,
+    ) -> Self {
         // Prepend the user agent with the provided user agent if it exists
         let user_agent = match user_agent {
             Some(ua) => format!("{ua} {}", get_user_agent()),
@@ -40,6 +47,10 @@ impl SqlFlightClient {
 
         let mut headers = HashMap::new();
         headers.insert("User-Agent".to_string(), user_agent);
+
+        if let Some(cache_control) = cache_control {
+            headers.insert("Cache-Control".to_string(), cache_control);
+        }
 
         SqlFlightClient {
             api_key,
@@ -153,11 +164,51 @@ impl SqlFlightClient {
                     .into_parts();
 
                 return Ok(FlightRecordBatchStream::new_from_flight_data(
-                    response_stream.map_err(FlightError::Tonic),
+                    response_stream.map_err(|e| FlightError::Tonic(Box::new(e))),
                 )
                 .with_headers(md));
             }
         }
         Err("No endpoints found".into())
+    }
+
+    pub async fn query_with_params(
+        &mut self,
+        query: &str,
+        params: Option<RecordBatch>,
+    ) -> std::result::Result<FlightRecordBatchStream, GenericError> {
+        if let Some(params) = params {
+            Ok(self.execute_prepared_statement(query, params).await?)
+        } else {
+            Ok(self.query(query).await?)
+        }
+    }
+
+    async fn execute_prepared_statement(
+        &mut self,
+        query: &str,
+        parameters: RecordBatch,
+    ) -> std::result::Result<FlightRecordBatchStream, GenericError> {
+        let mut client = FlightSqlServiceClient::new_from_inner(self.client.clone());
+        let mut prepared_stmt = client.prepare(query.to_string(), None).await?;
+
+        prepared_stmt.set_parameters(parameters)?;
+
+        let flight_info = prepared_stmt.execute().await?;
+
+        let endpoint = flight_info
+            .endpoint
+            .first()
+            .ok_or("No endpoint in flight info")?;
+
+        let stream = client
+            .do_get(
+                endpoint
+                    .ticket
+                    .clone()
+                    .ok_or("No flight ticket in response")?,
+            )
+            .await?;
+        Ok(stream)
     }
 }

--- a/src/flight.rs
+++ b/src/flight.rs
@@ -8,7 +8,6 @@ use arrow_flight::flight_service_client::FlightServiceClient;
 use arrow_flight::sql::client::FlightSqlServiceClient;
 use arrow_flight::FlightDescriptor;
 use arrow_flight::HandshakeRequest;
-use arrow_flight::HandshakeResponse;
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use bytes::Bytes;
@@ -21,7 +20,6 @@ use tonic::transport::Channel;
 use tonic::IntoRequest;
 
 pub struct SqlFlightClient {
-    token: Option<String>,
     headers: HashMap<String, String>,
     client: FlightServiceClient<Channel>,
     api_key: Option<String>,
@@ -56,11 +54,14 @@ impl SqlFlightClient {
             api_key,
             headers,
             client: FlightServiceClient::new(chan),
-            token: None,
         }
     }
 
-    async fn handshake(&mut self, username: &str, password: &str) -> Result<Bytes, ArrowError> {
+    async fn handshake(
+        &self,
+        username: &str,
+        password: &str,
+    ) -> Result<Option<String>, ArrowError> {
         let cmd = HandshakeRequest {
             protocol_version: 0,
             payload: Bytes::default(),
@@ -71,12 +72,15 @@ impl SqlFlightClient {
             .parse()
             .map_err(|_| ArrowError::ParseError("Cannot parse header".to_string()))?;
         req.metadata_mut().insert("authorization", val);
-        let req = self.set_request_headers(req)?;
+        let req = self.set_request_headers(req, None)?;
         let resp = self
             .client
+            .clone()
             .handshake(req)
             .await
             .map_err(|e| ArrowError::IpcError(format!("Can't handshake {e}")))?;
+
+        let mut token: Option<String> = None;
         if let Some(auth) = resp.metadata().get("authorization") {
             let auth = auth
                 .to_str()
@@ -86,34 +90,31 @@ impl SqlFlightClient {
                 Err(ArrowError::ParseError("Invalid auth header!".to_string()))?;
             }
             let auth = auth[bearer.len()..].to_string();
-            self.token = Some(auth);
+            token = Some(auth);
         }
-        let responses: Vec<HandshakeResponse> = resp
-            .into_inner()
-            .try_collect()
-            .await
-            .map_err(|_| ArrowError::ParseError("Can't collect responses".to_string()))?;
-        let resp = match responses.as_slice() {
-            [resp] => resp.payload.clone(),
-            [] => Bytes::new(),
-            _ => Err(ArrowError::ParseError(
-                "Multiple handshake responses".to_string(),
-            ))?,
-        };
-        Ok(resp)
+        Ok(token)
     }
 
-    async fn authenticate(&mut self, api_key: &str) -> std::result::Result<(), GenericError> {
-        if api_key.split('|').collect::<String>().len() < 2 {
-            return Err("Invalid API key format".into());
-        }
-        self.handshake("", api_key).await?;
-        Ok(())
+    async fn authenticate(&self) -> std::result::Result<Option<String>, GenericError> {
+        let (username, password) = match self.api_key {
+            Some(ref api_key) => {
+                if api_key.split('|').collect::<String>().len() < 2 {
+                    return Err("Invalid API key format".into());
+                }
+                ("", api_key.as_str())
+            }
+            None => return Ok(None),
+        };
+
+        let token = self.handshake(username, password).await?;
+
+        Ok(token)
     }
 
     fn set_request_headers<T>(
         &self,
         mut req: tonic::Request<T>,
+        token: Option<String>,
     ) -> Result<tonic::Request<T>, ArrowError> {
         for (k, v) in &self.headers {
             let k = AsciiMetadataKey::from_str(k.as_str()).map_err(|e| {
@@ -124,7 +125,7 @@ impl SqlFlightClient {
             })?;
             req.metadata_mut().insert(k, v);
         }
-        if let Some(token) = &self.token {
+        if let Some(token) = token {
             let val = format!("Bearer {token}").parse().map_err(|e| {
                 ArrowError::ParseError(format!("Cannot convert token to header value: {e}"))
             })?;
@@ -134,19 +135,17 @@ impl SqlFlightClient {
     }
 
     pub async fn query(
-        &mut self,
+        &self,
         query: &str,
     ) -> std::result::Result<FlightRecordBatchStream, GenericError> {
-        let api_key = self.api_key.clone();
-        if let Some(api_key) = api_key {
-            self.authenticate(&api_key).await?;
-        }
+        let token = self.authenticate().await?;
 
         let descriptor = FlightDescriptor::new_cmd(query.to_string());
-        let req = self.set_request_headers(descriptor.into_request())?;
+        let req = self.set_request_headers(descriptor.into_request(), token.clone())?;
 
         let info = self
             .client
+            .clone()
             .get_flight_info(req)
             .await
             .map_err(status_to_arrow_error)?
@@ -155,9 +154,10 @@ impl SqlFlightClient {
         for ep in info.endpoint {
             if let Some(tkt) = ep.ticket {
                 let req = tkt.into_request();
-                let req = self.set_request_headers(req)?;
+                let req = self.set_request_headers(req, token.clone())?;
                 let (md, response_stream, _ext) = self
                     .client
+                    .clone()
                     .do_get(req)
                     .await
                     .map_err(status_to_arrow_error)?
@@ -173,7 +173,7 @@ impl SqlFlightClient {
     }
 
     pub async fn query_with_params(
-        &mut self,
+        &self,
         query: &str,
         params: Option<RecordBatch>,
     ) -> std::result::Result<FlightRecordBatchStream, GenericError> {
@@ -185,7 +185,7 @@ impl SqlFlightClient {
     }
 
     async fn execute_prepared_statement(
-        &mut self,
+        &self,
         query: &str,
         parameters: RecordBatch,
     ) -> std::result::Result<FlightRecordBatchStream, GenericError> {

--- a/src/flight.rs
+++ b/src/flight.rs
@@ -15,14 +15,16 @@ use futures::stream;
 use futures::TryStreamExt;
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::Arc;
 use tonic::metadata::AsciiMetadataKey;
 use tonic::transport::Channel;
 use tonic::IntoRequest;
 
+#[derive(Clone)]
 pub struct SqlFlightClient {
-    headers: HashMap<String, String>,
+    headers: Arc<HashMap<String, String>>,
     client: FlightServiceClient<Channel>,
-    api_key: Option<String>,
+    api_key: Option<Arc<str>>,
 }
 
 impl SqlFlightClient {
@@ -46,8 +48,8 @@ impl SqlFlightClient {
         }
 
         SqlFlightClient {
-            api_key,
-            headers,
+            api_key: api_key.map(|s| Arc::from(s.into_boxed_str())),
+            headers: Arc::new(headers),
             client: FlightServiceClient::new(chan),
         }
     }
@@ -91,12 +93,12 @@ impl SqlFlightClient {
     }
 
     async fn authenticate(&self) -> std::result::Result<Option<String>, GenericError> {
-        let (username, password) = match self.api_key {
-            Some(ref api_key) => {
-                if api_key.split('|').collect::<String>().len() < 2 {
+        let (username, password) = match &self.api_key {
+            Some(api_key) => {
+                if api_key.to_string().split('|').collect::<String>().len() < 2 {
                     return Err("Invalid API key format".into());
                 }
-                ("", api_key.as_str())
+                ("", api_key.as_ref())
             }
             None => return Ok(None),
         };
@@ -111,7 +113,7 @@ impl SqlFlightClient {
         mut req: tonic::Request<T>,
         token: Option<String>,
     ) -> Result<tonic::Request<T>, ArrowError> {
-        for (k, v) in &self.headers {
+        for (k, v) in self.headers.iter() {
             let k = AsciiMetadataKey::from_str(k.as_str()).map_err(|e| {
                 ArrowError::ParseError(format!("Cannot convert header key \"{k}\": {e}"))
             })?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod client;
 mod config;
 mod flight;
 mod tls;
+mod util;
 
 pub use client::SpiceClient as Client;
 pub use client::SpiceClientBuilder as ClientBuilder;

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,4 +1,7 @@
+use base64::{engine::general_purpose, Engine as _};
 use std::str::FromStr;
+
+use std::io::Write;
 use tonic::transport::channel::{ClientTlsConfig, Endpoint};
 use tonic::transport::Channel;
 
@@ -6,18 +9,17 @@ use crate::config::GenericError;
 
 pub fn system_tls_certificate() -> Result<tonic::transport::Certificate, GenericError> {
     // Load root certificates found in the platform’s native certificate store.
-    let certs = rustls_native_certs::load_native_certs()?;
+    // Use the same pem format as spiceai cloud connector: https://github.com/spiceai/spiceai/blob/571007c4be89a2a9892e3bd0eb43f8bd28464a69/crates/flight_client/src/tls.rs#L47
+    let cert_result = rustls_native_certs::load_native_certs();
 
-    let concatenated_pems = certs
-        .iter()
-        .filter_map(|cert| {
-            let mut buf = &cert.0[..];
-            rustls_pemfile::certs(&mut buf).ok()?.pop()
-        })
-        .map(String::from_utf8)
-        .collect::<Result<String, _>>()?;
+    let mut pem = Vec::new();
+    for cert in cert_result.certs {
+        pem.write_all(b"-----BEGIN CERTIFICATE-----\n")?;
+        pem.write_all(general_purpose::STANDARD.encode(cert.as_ref()).as_bytes())?;
+        pem.write_all(b"\n-----END CERTIFICATE-----\n")?;
+    }
 
-    Ok(tonic::transport::Certificate::from_pem(concatenated_pems))
+    Ok(tonic::transport::Certificate::from_pem(pem))
 }
 
 pub async fn new_tls_flight_channel(https_url: &str) -> Result<Channel, GenericError> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,142 @@
+pub use backoff::future::retry;
+pub use backoff::Error as RetryError;
+
+use std::time::Duration;
+
+use backoff::backoff::Backoff;
+
+// Fibonacci-based backoff delay intervals capped at 5 mins
+const BACKOFF_INTERVALS_MS: [u64; 14] = [
+    1000, 1000, 2000, 3000, 5000, 8000, 13000, 21000, 34000, 55000, 89000, 144_000, 233_000,
+    300_000,
+];
+
+#[derive(Debug)]
+pub struct FibonacciBackoff {
+    num_retries: usize,
+    pub randomization_factor: f64,
+    pub max_retries: Option<usize>,
+    pub max_duration: Option<Duration>,
+}
+
+impl Default for FibonacciBackoff {
+    fn default() -> FibonacciBackoff {
+        FibonacciBackoff {
+            num_retries: 0,
+            randomization_factor: 0.3,
+            max_retries: None,
+            max_duration: None,
+        }
+    }
+}
+
+impl Backoff for FibonacciBackoff {
+    fn reset(&mut self) {
+        self.num_retries = 0;
+    }
+
+    fn next_backoff(&mut self) -> Option<Duration> {
+        self.num_retries += 1;
+
+        if let Some(max_retries) = self.max_retries {
+            if self.num_retries > max_retries {
+                return None;
+            }
+        }
+
+        let interval = if self.num_retries >= BACKOFF_INTERVALS_MS.len() {
+            Duration::from_millis(BACKOFF_INTERVALS_MS[BACKOFF_INTERVALS_MS.len() - 1])
+        } else {
+            Duration::from_millis(BACKOFF_INTERVALS_MS[self.num_retries])
+        };
+
+        let randomized_interval = get_random_value_from_interval(
+            self.randomization_factor,
+            rand::random::<f64>(),
+            interval,
+        );
+
+        let final_interval = if let Some(max_duration) = self.max_duration {
+            if randomized_interval > max_duration {
+                max_duration
+            } else {
+                randomized_interval
+            }
+        } else {
+            randomized_interval
+        };
+
+        Some(final_interval)
+    }
+}
+
+fn get_random_value_from_interval(
+    randomization_factor: f64,
+    random: f64,
+    current_interval: Duration,
+) -> Duration {
+    let current_interval_nanos = duration_to_nanos(current_interval);
+
+    let delta = randomization_factor * current_interval_nanos;
+    let min_interval = current_interval_nanos - delta;
+    let max_interval = current_interval_nanos + delta;
+    // Get a random value from the range [minInterval, maxInterval].
+    // The formula used below has a +1 because if the minInterval is 1 and the maxInterval is 3 then
+    // we want a 33% chance for selecting either 1, 2 or 3.
+    let diff = max_interval - min_interval;
+    let nanos = min_interval + (random * (diff + 1.0));
+    nanos_to_duration(nanos)
+}
+
+pub struct FibonacciBackoffBuilder {
+    randomization_factor: f64,
+    max_retries: Option<usize>,
+    max_duration: Option<Duration>,
+}
+
+impl FibonacciBackoffBuilder {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            randomization_factor: 0.3,
+            max_retries: None,
+            max_duration: None,
+        }
+    }
+
+    /// Set the maximum number of retries. None means no limit.
+    #[must_use]
+    pub fn max_retries(mut self, value: Option<usize>) -> Self {
+        self.max_retries = value;
+        self
+    }
+
+    #[must_use]
+    pub fn build(self) -> FibonacciBackoff {
+        FibonacciBackoff {
+            randomization_factor: self.randomization_factor,
+            max_retries: self.max_retries,
+            max_duration: self.max_duration,
+            ..FibonacciBackoff::default()
+        }
+    }
+}
+
+impl Default for FibonacciBackoffBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn duration_to_nanos(d: Duration) -> f64 {
+    d.as_secs() as f64 * 1_000_000_000.0 + f64::from(d.subsec_nanos())
+}
+
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_sign_loss)]
+fn nanos_to_duration(nanos: f64) -> Duration {
+    let secs = nanos / 1_000_000_000.0;
+    let nanos = nanos as u64 % 1_000_000_000;
+    Duration::new(secs as u64, nanos as u32)
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,4 @@
+// Use Fibonacci backoff util from spiceai: https://github.com/spiceai/spiceai/tree/trunk/crates/util/src
 pub use backoff::future::retry;
 pub use backoff::Error as RetryError;
 

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -29,7 +29,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn test_query() {
-        let mut spice_client = new_client().await;
+        let spice_client = new_client().await;
         match spice_client.query(
             r#"SELECT number, "timestamp", base_fee_per_gas, base_fee_per_gas / 1e9 AS base_fee_per_gas_gwei FROM eth.recent_blocks limit 10"#,
             ).await {
@@ -56,7 +56,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn test_query_streaming() {
-        let mut spice_client = new_client().await;
+        let spice_client = new_client().await;
         match spice_client.query(
             "SELECT number, \"timestamp\", base_fee_per_gas, base_fee_per_gas / 1e9 AS base_fee_per_gas_gwei FROM eth.blocks limit 2000",
             ).await {

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -1,9 +1,18 @@
 #[cfg(test)]
 mod tests {
+    use arrow::array::{ArrayRef, Float64Array, Int32Array};
+    use arrow::compute::concat_batches;
+    use arrow::datatypes::{
+        DataType::{Float64, Int32},
+        Field, Schema,
+    };
+    use arrow::record_batch::RecordBatch;
+    use arrow::util::pretty::pretty_format_batches;
     use futures::stream::StreamExt;
     use spiceai::{Client, ClientBuilder};
     use std::env;
     use std::path::Path;
+    use std::sync::Arc;
 
     async fn new_client() -> Client {
         dotenv::from_path(Path::new(".env.local")).ok();
@@ -24,6 +33,105 @@ mod tests {
     #[tokio::test]
     async fn test_new_client_builder() {
         new_client().await;
+    }
+
+    async fn new_local_client() -> Client {
+        ClientBuilder::new()
+            .build()
+            .await
+            .expect("Failed to create client")
+    }
+
+    pub fn create_param_batch() -> RecordBatch {
+        let fields = vec![
+            Arc::new(Field::new("$1", Int32, true)),
+            Arc::new(Field::new("$2", Float64, true)),
+        ];
+        let columns = vec![
+            Arc::new(Int32Array::from(vec![1])) as ArrayRef,
+            Arc::new(Float64Array::from(vec![1.0])) as ArrayRef,
+        ];
+
+        RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
+            .expect("Failed to create RecordBatch")
+    }
+
+    fn get_expected_result() -> String {
+        String::from("+----------+----------------------+-------------+\n| VendorID | tpep_pickup_datetime | fare_amount |\n+----------+----------------------+-------------+\n| 1        | 2024-01-03T13:34:41  | 1.5         |\n| 1        | 2024-01-06T14:49:10  | 2.0         |\n| 1        | 2024-01-16T07:28:44  | 2.0         |\n| 1        | 2024-01-18T02:11:51  | 2.0         |\n| 1        | 2024-01-18T17:47:40  | 2.0         |\n+----------+----------------------+-------------+")
+    }
+
+    #[tokio::test]
+    async fn test_local_query() {
+        let _ = rustls::crypto::CryptoProvider::install_default(
+            rustls::crypto::aws_lc_rs::default_provider(),
+        );
+        let spice_client = new_local_client().await;
+        match spice_client
+            .query("SELECT VendorID, tpep_pickup_datetime, fare_amount FROM taxi_trips WHERE VendorID == 1 and fare_amount > 1.0 ORDER BY fare_amount, tpep_pickup_datetime LIMIT 5;")
+            .await
+        {
+            Ok(mut flight_data_stream) => {
+                let mut batches = Vec::new();
+                // Read back RecordBatches
+                while let Some(batch) = flight_data_stream.next().await {
+                    match batch {
+                        Ok(batch) => {
+                            batches.push(batch);
+                        }
+                        Err(e) => {
+                            panic!("Error: {e}")
+                        }
+                    }
+                }
+                let batch_concat = concat_batches(&batches[0].schema(), &batches).expect("Failed to concat batches");
+                let formatted = format!("{}", pretty_format_batches(&[batch_concat.clone()]).expect("Failed to format batches"));
+                assert_eq!(batch_concat.num_columns(), 3);
+                assert_eq!(batch_concat.num_rows(), 5);
+                assert_eq!(formatted, get_expected_result());
+            }
+            Err(e) => {
+                panic!("Error: {e}");
+            }
+        };
+    }
+
+    #[tokio::test]
+    async fn test_local_query_with_params() {
+        let _ = rustls::crypto::CryptoProvider::install_default(
+            rustls::crypto::aws_lc_rs::default_provider(),
+        );
+        let spice_client = new_local_client().await;
+        let params = create_param_batch();
+        match spice_client
+            .query_with_params(
+                "SELECT VendorID, tpep_pickup_datetime, fare_amount FROM taxi_trips WHERE VendorID == $1 and fare_amount > $2 ORDER BY fare_amount, tpep_pickup_datetime LIMIT 5;",
+                Some(params),
+            )
+            .await
+        {
+            Ok(mut flight_data_stream) => {
+                let mut batches = Vec::new();
+                // Read back RecordBatches
+                while let Some(batch) = flight_data_stream.next().await {
+                    match batch {
+                        Ok(batch) => {
+                            batches.push(batch);
+                        }
+                        Err(e) => {
+                            panic!("Error: {e}")
+                        }
+                    }
+                }
+                let batch_concat = concat_batches(&batches[0].schema(), &batches).expect("Failed to concat batches");
+                let formatted = format!("{}", pretty_format_batches(&[batch_concat.clone()]).expect("Failed to format batches"));
+                assert_eq!(batch_concat.num_columns(), 3);
+                assert_eq!(batch_concat.num_rows(), 5);
+                assert_eq!(formatted, get_expected_result());
+            }
+            Err(e) => {
+                panic!("Error: {e}");
+            }
+        };
     }
 
     #[tokio::test]

--- a/tests/readme_test.rs
+++ b/tests/readme_test.rs
@@ -12,7 +12,7 @@ mod tests {
         dotenv::from_path(Path::new(".env.local")).ok();
         let api_key = env::var("API_KEY").expect("API_KEY not found");
 
-        let mut client = Client::new(&api_key)
+        let client = Client::new(&api_key)
             .await
             .expect("SpiceClient should be created");
         let data = client.query("SELECT * FROM taxi_trips LIMIT 10;").await;
@@ -30,7 +30,7 @@ mod tests {
         dotenv::from_path(Path::new(".env.local")).ok();
         let api_key = env::var("API_KEY").expect("API_KEY not found");
 
-        let mut client = ClientBuilder::new()
+        let client = ClientBuilder::new()
             .api_key(&api_key)
             .use_spiceai_cloud()
             .build()
@@ -48,7 +48,7 @@ mod tests {
     #[tokio::test]
     async fn test_readme_builder_local() {
         // NOTE: If you're changing the code below, make sure you update the README.md.
-        let mut client = ClientBuilder::new()
+        let client = ClientBuilder::new()
             .build()
             .await
             .expect("SpiceClient should be created");


### PR DESCRIPTION
## 🗣 Description

- New method `query_with_params` to allow for parametrized query
- Refactor the `SpiceClient` and `SqlFlightClient` to no longer take a `&mut self` for `query` and make these 2 structs cheap to clone.
- Retry on the query known connection reset error emitted from spiceai by matching the `spiceai-retryable` metadata in the `is_transient_error` method.
- Add `cache_control` to `SqlFlightClient` and `SpiceClientBuilder` to specify `cache-control` header when sending requests.
- Upgrade dependency to allow for integration in spiceai test operator.

## 🔨 Related Issues

- https://github.com/spiceai/spiceai/issues/6121
- https://github.com/spiceai/spiceai/issues/6122

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
