### PR TITLE
Update publish workflow to use crates.io OIDC auth to get registry token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: cratesio
+    permissions:
+      id-token: write # Required for OIDC token exchange with crates.io
     steps:
       - uses: actions/checkout@v4
+
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -24,4 +29,4 @@ jobs:
 
       - run: cargo publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,13 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: rust-lang/crates-io-auth-action@v1
+      # Using a tag for a 3rd party Action that is not pinned to a commit can lead to executing an untrusted Action through a supply chain attack.
+      # https://github.com/rust-lang/crates-io-auth-action/releases/tag/v1.0.1
+      - uses: rust-lang/crates-io-auth-action@e919bc7605cde86df457cf5b93c5e103838bd879
         id: auth
 
       - name: Install Rust toolchain
-        # Using a tag for a 3rd party Action that is not pinned to a commit can lead to executing an untrusted Action through a supply chain attack.
-        # https://github.com/rust-lang/crates-io-auth-action/releases/tag/v1.0.1
-        uses: actions-rs/toolchain@e919bc7605cde86df457cf5b93c5e103838bd879
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,9 @@ jobs:
         id: auth
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        # Using a tag for a 3rd party Action that is not pinned to a commit can lead to executing an untrusted Action through a supply chain attack.
+        # https://github.com/rust-lang/crates-io-auth-action/releases/tag/v1.0.1
+        uses: actions-rs/toolchain@e919bc7605cde86df457cf5b93c5e103838bd879
         with:
           profile: minimal
           toolchain: stable


### PR DESCRIPTION
## 🗣 Description

Update publish workflow to use crates.io trusted publishing https://crates.io/docs/trusted-publishing

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
