### PR TITLE
Upgrade Rust to 1.93.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-          - stable
+          - 1.93.1
           - beta
           - nightly
     steps:
@@ -67,7 +67,7 @@ jobs:
             windows-2022,
           ]
         toolchain:
-          - stable
+          - 1.93.1
           - beta
     steps:
       # actions/checkout v4.2.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.93.1
           override: true
 
       - run: cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spiceai"
 version = "3.2.0"
 edition = "2024"
+rust-version = "1.93.1"
 description = "SDK for Spice.ai, an open-source runtime and platform for building AI-driven software."
 license = "Apache-2.0"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.93.1"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary
- pin the crate MSRV/toolchain to Rust 1.93.1 in Cargo.toml and rust-toolchain.toml
- update GitHub Actions build and publish workflows to use Rust 1.93.1 instead of floating stable
- keep beta and nightly coverage in CI

## Validation
- cargo fmt --check
- cargo build

## Notes
- cargo test was not run locally because the integration flow depends on a running Spice runtime and optional credentials