### PR TITLE
Add query bindings, dataset refresh, and GitHub release publishing flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/end_game.md
+++ b/.github/ISSUE_TEMPLATE/end_game.md
@@ -28,13 +28,12 @@ assignees: ''
 - [ ] Test the [`spice-rs` sample](https://github.com/spiceai/samples/tree/trunk/client-sdk/spice-rs-sdk-sample) using the latest `trunk` SDK version.
 - [ ] Update [release notes](https://github.com/spiceai/spice-rs/blob/trunk/docs/release_notes)
   - [ ] Ensure all contributors have been acknowledged.
-- [ ] Verify the version in `Cargo.toml` is correct and match the milestone version.
+- [ ] Verify `Cargo.toml` is set to the milestone version and the release tag will match it.
 - [ ] Run [Test CI](https://github.com/spiceai/spice-rs/actions/workflows/build.yml) and ensure it is green on the trunk branch.
 - [ ] QA DRI sign-off
 - [ ] Docs DRI sign-off
-- [ ] Create a new branch `release-v[semver]` for the release from trunk. E.g. `release-v3.0.0`
-- [ ] Release the new version by creating and publishing a latest [GitHub Release](https://github.com/spiceai/spice-rs/releases/new) with the tag from the release branch. E.g. `v3.0.0`.
-- [ ] Ensure the [publish](https://github.com/spiceai/spice-rs/actions/workflows/publish.yml) workflow has triggered, and successfully published the package.
+- [ ] Create or publish the GitHub Release for the target version tag.
+- [ ] If this should be the stable SDK release, mark the GitHub Release as Latest.
+- [ ] Ensure the [publish](https://github.com/spiceai/spice-rs/actions/workflows/publish.yml) workflow completed successfully and published the package.
 - [ ] Run a test pass using the [`spice-rs` sample](https://github.com/spiceai/samples/tree/trunk/client-sdk/spice-rs-sdk-sample) using the latest published version.
-- [ ] Update the version in `Cargo.toml` to the next release version.
 - [ ] The SDK release is added to the next [Spice release notes](https://github.com/spiceai/spiceai/tree/trunk/docs/release_notes)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
         os:
           [
             ubuntu-latest,
-            ubuntu-22.04,
+            ubuntu-24.04,
             macos-latest,
             macos-14,
             windows-latest,
@@ -141,7 +141,11 @@ jobs:
 
       - name: Stop spice and check logs
         working-directory: spice_qs
-        if: "!startsWith(matrix.os, 'windows') && always()"
+        # Guard on spice_qs existing: a failed `spice install`/`spice init`
+        # never creates the working-directory, which would otherwise make this
+        # always() step error with "No such file or directory" and mask the
+        # real failure.
+        if: "always() && !startsWith(matrix.os, 'windows') && hashFiles('spice_qs/**') != ''"
         run: |
           killall spice || true
           cat spice.log

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,35 +2,154 @@ name: crates-publish
 
 on:
   release:
-    types: [published]
+    types: [published, released, edited]
 
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Git tag to publish, for example v3.2.0
+        required: true
+        type: string
+
+  workflow_call:
+    inputs:
+      tag:
+        description: Git tag to publish, for example v3.2.0
+        required: false
+        type: string
 
 jobs:
   publish:
+    concurrency:
+      group: crates-publish-${{ github.event.release.tag_name || inputs.tag || github.ref }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     environment: cratesio
     permissions:
+      contents: read
       id-token: write # Required for OIDC token exchange with crates.io
     steps:
       # actions/checkout v4.2.2
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag || github.ref }}
+
+      - name: Determine whether publish should run
+        id: preflight
+        env:
+          EVENT_ACTION: ${{ github.event.action }}
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_DRAFT: ${{ github.event.release.draft }}
+          RELEASE_ID: ${{ github.event.release.id }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          should_publish=false
+          skip_reason=''
+
+          if [[ "${EVENT_NAME}" == "release" ]]; then
+            if [[ "${RELEASE_DRAFT}" == "true" ]]; then
+              skip_reason='Draft releases do not trigger publishing.'
+            elif [[ "${EVENT_ACTION}" == "published" || "${EVENT_ACTION}" == "released" ]]; then
+              should_publish=true
+            elif [[ "${EVENT_ACTION}" == "edited" ]]; then
+              latest_release_id="$({
+                curl -fsSL \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                  -H "X-GitHub-Api-Version: 2022-11-28" \
+                  "https://api.github.com/repos/${REPOSITORY}/releases/latest" |
+                  jq -r '.id'
+              } 2>/dev/null || true)"
+
+              if [[ -n "${latest_release_id}" && "${latest_release_id}" == "${RELEASE_ID}" ]]; then
+                should_publish=true
+              else
+                skip_reason='Edited release is not the latest published release.'
+              fi
+            else
+              skip_reason="Release action ${EVENT_ACTION} does not trigger publishing."
+            fi
+          else
+            should_publish=true
+          fi
+
+          crate_name="$(awk -F'"' '
+            $0 == "[package]" { in_package=1; next }
+            /^\[/ && $0 != "[package]" { in_package=0 }
+            in_package && $1 ~ /^[[:space:]]*name = / { print $2; exit }
+          ' Cargo.toml)"
+
+          crate_version="$(awk -F'"' '
+            $0 == "[package]" { in_package=1; next }
+            /^\[/ && $0 != "[package]" { in_package=0 }
+            in_package && $1 ~ /^[[:space:]]*version = / { print $2; exit }
+          ' Cargo.toml)"
+
+          if [[ -z "${crate_name}" || -z "${crate_version}" ]]; then
+            echo "Failed to determine crate metadata from Cargo.toml" >&2
+            exit 1
+          fi
+
+          if [[ -n "${RELEASE_TAG}" ]]; then
+            if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+              echo "Release tag ${RELEASE_TAG} must match vX.Y.Z or vX.Y.Z-suffix" >&2
+              exit 1
+            fi
+
+            tag_version="${RELEASE_TAG#v}"
+            if [[ "${crate_version}" != "${tag_version}" ]]; then
+              echo "Release tag ${RELEASE_TAG} does not match Cargo.toml version ${crate_version}" >&2
+              exit 1
+            fi
+          elif [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo "workflow_dispatch requires a tag input" >&2
+            exit 1
+          fi
+
+          if [[ "${should_publish}" == "true" ]]; then
+            if curl -fsSL "https://crates.io/api/v1/crates/${crate_name}/${crate_version}" >/dev/null; then
+              should_publish=false
+              skip_reason="${crate_name} ${crate_version} is already published to crates.io."
+            fi
+          fi
+
+          if [[ "${should_publish}" == "true" ]]; then
+            decision_message="Publishing ${crate_name} ${crate_version}."
+          else
+            decision_message="${skip_reason}"
+          fi
+
+          echo "should_publish=${should_publish}" >> "${GITHUB_OUTPUT}"
+          echo "crate_name=${crate_name}" >> "${GITHUB_OUTPUT}"
+          echo "crate_version=${crate_version}" >> "${GITHUB_OUTPUT}"
+          echo "decision_message=${decision_message}" >> "${GITHUB_OUTPUT}"
+
+      - name: Publish decision
+        run: echo "${{ steps.preflight.outputs.decision_message }}"
 
       # rust-lang/crates-io-auth-action v1.0.1
       # https://github.com/rust-lang/crates-io-auth-action/releases/tag/v1.0.1
       - uses: rust-lang/crates-io-auth-action@e919bc7605cde86df457cf5b93c5e103838bd879
         id: auth
+        if: ${{ steps.preflight.outputs.should_publish == 'true' }}
 
       - name: Install Rust toolchain
         # actions-rs/toolchain v1.0.7
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+        if: ${{ steps.preflight.outputs.should_publish == 'true' }}
         with:
           profile: minimal
           toolchain: stable
           override: true
 
       - run: cargo build
+        if: ${{ steps.preflight.outputs.should_publish == 'true' }}
 
       - run: cargo publish
+        if: ${{ steps.preflight.outputs.should_publish == 'true' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,15 @@
 name = "spiceai"
 version = "3.2.0"
 edition = "2024"
+rust-version = "1.93.1"
 description = "SDK for Spice.ai, an open-source runtime and platform for building AI-driven software."
 license = "Apache-2.0"
+repository = "https://github.com/spiceai/spice-rs"
+homepage = "https://spice.ai"
+documentation = "https://docs.rs/spiceai"
+readme = "README.md"
+keywords = ["spiceai", "sql", "arrow", "flight", "sdk"]
+categories = ["api-bindings", "database"]
 
 [dependencies]
 arrow = { version = "57.2", features = ["prettyprint"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,4 @@ winver = "1.0.0"
 
 [dev-dependencies]
 regex = "1.10.6"
+wiremock = "0.6.5"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
 ### Parameterized queries
 
-For common scalar bindings, use `QueryParameters`. For advanced Arrow parameter batches, use `Client::sql_with_params`.
+For common scalar bindings, use `QueryParameters`. For any Arrow data type, wrap a one-element Arrow array with `QueryParameter::array(...)`. For advanced Arrow parameter batches, use `Client::sql_with_params`.
 
 ```rust,no_run
 use spiceai::{ClientBuilder, QueryParameters, StreamExt};

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Rust Spice SDK
 
-Rust SDK for Spice.ai
+Rust SDK for Spice.ai.
 
 ## Installation
 
-Add Spice SDK
+Add the SDK:
 
 ```bash
 cargo add spiceai
@@ -12,60 +12,131 @@ cargo add spiceai
 
 ## Usage
 
-<!-- NOTE: If you're changing the code examples below, make sure you update `tests/readme_test.rs`. -->
+### Query a local Spice runtime
 
-### Usage with locally running [spice runtime](https://github.com/spiceai/spiceai)
+Follow the [quickstart guide](https://github.com/spiceai/spiceai?tab=readme-ov-file#%EF%B8%8F-quickstart-local-machine) to install and run Spice locally.
 
-Follow the [quickstart guide](https://github.com/spiceai/spiceai?tab=readme-ov-file#%EF%B8%8F-quickstart-local-machine) to install and run spice locally
+```rust,no_run
+use spiceai::{ClientBuilder, StreamExt};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+  let client = ClientBuilder::new().build().await?;
+
+  let mut stream = client
+    .sql(
+      "SELECT trip_distance, total_amount FROM taxi_trips ORDER BY trip_distance DESC LIMIT 10;",
+    )
+    .await?;
+
+  while let Some(batch) = stream.next().await {
+    println!("rows: {}", batch?.num_rows());
+  }
+
+  Ok(())
+}
+```
+
+### Use Arrow types re-exported by the SDK
+
+The SDK re-exports `arrow` as `spiceai::arrow`, which keeps your Arrow types aligned with the SDK's public API.
+
+```rust,no_run
+use spiceai::{arrow::array::Float64Array, ClientBuilder, StreamExt};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+  let client = ClientBuilder::new().build().await?;
+
+  let mut stream = client
+    .sql("SELECT trip_distance FROM taxi_trips ORDER BY trip_distance DESC LIMIT 1;")
+    .await?;
+
+  if let Some(batch) = stream.next().await {
+    let batch = batch?;
+    let values = batch
+      .column(0)
+      .as_any()
+      .downcast_ref::<Float64Array>()
+      .expect("trip_distance should be Float64");
+
+    println!("longest trip: {}", values.value(0));
+  }
+
+  Ok(())
+}
+```
+
+### Parameterized queries
+
+For common scalar bindings, use `QueryParameters`. For advanced Arrow parameter batches, use `Client::sql_with_params`.
+
+```rust,no_run
+use spiceai::{ClientBuilder, QueryParameters, StreamExt};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+  let client = ClientBuilder::new().build().await?;
+
+  let mut stream = client
+    .sql_with_bindings(
+      "SELECT VendorID, fare_amount FROM taxi_trips WHERE VendorID = $1 AND fare_amount > $2 LIMIT 5;",
+      QueryParameters::new().push(1_i32).push(1.0_f64),
+    )
+    .await?;
+
+  while let Some(batch) = stream.next().await {
+    println!("rows: {}", batch?.num_rows());
+  }
+
+  Ok(())
+}
+```
+
+### Connect to Spice.ai Cloud
 
 ```rust,no_run
 use spiceai::ClientBuilder;
 
 #[tokio::main]
-async fn main() {
-  let client = ClientBuilder::new()
-    .flight_url("http://localhost:50051")
-    .build()
-    .await
-    .unwrap();
-
-  let data = client.query("SELECT trip_distance, total_amount FROM taxi_trips ORDER BY trip_distance DESC LIMIT 10;").await;
-}
-```
-
-### New client with <https://spice.ai> cloud
-
-```rust
-use spiceai::ClientBuilder;
-
-#[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
   let client = ClientBuilder::new()
     .api_key("API_KEY")
     .use_spiceai_cloud()
     .build()
-    .await
-    .unwrap();
+    .await?;
+
+  let _ = client;
+  Ok(())
 }
 ```
 
-### Arrow Query
+### Async query jobs and dataset refresh
 
-SQL Query
+Async query management and dataset refresh use the Spice HTTP API, so configure `http_url()` in addition to the Flight endpoint when needed.
 
-```rust
-use spiceai::ClientBuilder;
+```rust,no_run
+use spiceai::{ClientBuilder, DatasetRefreshMode, DatasetRefreshRequest};
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
   let client = ClientBuilder::new()
-    .api_key("API_KEY")
-    .use_spiceai_cloud()
+    .http_url("http://localhost:8090")
     .build()
-    .await
-    .unwrap();
+    .await?;
 
-  let data = client.query("SELECT * FROM taxi_trips LIMIT 10;").await;
+  let job = client.query("SELECT * FROM large_table").await?;
+  println!("query status: {}", job.status().await?);
+
+  let response = client
+    .refresh_dataset_with_options(
+      "taxi_trips",
+      DatasetRefreshRequest::new().with_refresh_mode(DatasetRefreshMode::Full),
+    )
+    .await?;
+
+  println!("{}", response.message);
+  Ok(())
 }
 ```
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,8 +1,10 @@
 use crate::flight::RetryableQueryStream;
+use crate::params::{QueryParameterError, QueryParameters};
 use crate::query::{QueryError, QueryHttpClient, QueryJob};
 use crate::util::{FibonacciBackoffBuilder, RetryError, retry};
 use crate::{
     config::{GenericError, SPICE_CLOUD_FLIGHT_ADDR, SPICE_LOCAL_FLIGHT_ADDR},
+    dataset::{DatasetError, DatasetRefreshRequest, DatasetRefreshResponse},
     flight::{SqlFlightClient, is_connection_reset_generic_error},
     tls::{ensure_crypto_provider, new_tls_flight_channel},
 };
@@ -21,6 +23,9 @@ pub enum Error {
     Query {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+
+    #[snafu(display("Failed to build query parameters: {source}"))]
+    ParameterBindings { source: QueryParameterError },
 
     #[snafu(display("Failed to process query stream: {source}"))]
     QueryStream { source: FlightError },
@@ -45,8 +50,8 @@ impl SpiceClientConfig {
     }
 }
 
-/// The `SpiceClient` is the main entry point for interacting with the Spice API.
-/// It provides methods for querying the Spice Flight endpoint.
+/// The `SpiceClient` is the main entry point for interacting with Spice.
+/// It provides methods for Flight SQL queries and runtime HTTP APIs.
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone)]
 pub struct SpiceClient {
@@ -179,6 +184,46 @@ impl SpiceClient {
         })
         .await
         .map_err(|e| Error::Query { source: e })
+    }
+
+    /// Executes a synchronous parameterized SQL query using scalar bindings.
+    ///
+    /// This is a convenience wrapper over [`sql_with_params()`](Self::sql_with_params)
+    /// for the common case of binding a single row of scalar values. For advanced
+    /// Arrow parameter batches, use [`sql_with_params()`](Self::sql_with_params).
+    ///
+    /// ```
+    /// # use spiceai::{Client, QueryParameters};
+    /// #
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// #  let client = Client::new("API_KEY").await.unwrap();
+    /// #  let _ = client
+    /// #    .sql_with_bindings(
+    /// #      "SELECT * FROM taxi_trips WHERE VendorID = $1 AND fare_amount > $2 LIMIT 10;",
+    /// #      QueryParameters::new().push(1_i32).push(1.0_f64),
+    /// #    )
+    /// #    .await;
+    /// # }
+    /// ```
+    ///
+    /// ## Errors
+    ///
+    /// - [`Error::ParameterBindings`] if the bindings cannot be converted into an Arrow batch
+    /// - [`Error::Query`] for query execution errors
+    pub async fn sql_with_bindings(
+        &self,
+        query: &str,
+        params: QueryParameters,
+    ) -> Result<RetryableQueryStream, Error> {
+        let params = params
+            .into_record_batch()
+            .map_err(|source| Error::ParameterBindings { source })?;
+
+        match params {
+            Some(params) => self.sql_with_params(query, Some(params)).await,
+            None => self.sql(query).await,
+        }
     }
 
     /// Submits an async SQL query and returns a [`QueryJob`] handle.
@@ -369,6 +414,49 @@ impl SpiceClient {
         let job = QueryJob::new(query_id.to_string(), Arc::clone(http_client));
         job.cancel().await
     }
+
+    /// Triggers an on-demand refresh for an accelerated dataset.
+    ///
+    /// **Note:** Requires [`http_url()`](SpiceClientBuilder::http_url) to be configured.
+    ///
+    /// ```no_run
+    /// # use spiceai::ClientBuilder;
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// let client = ClientBuilder::new()
+    ///     .http_url("http://localhost:8090")
+    ///     .build()
+    ///     .await?;
+    ///
+    /// let response = client.refresh_dataset("taxi_trips").await?;
+    /// println!("{}", response.message);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn refresh_dataset(
+        &self,
+        dataset_name: &str,
+    ) -> Result<DatasetRefreshResponse, DatasetError> {
+        self.refresh_dataset_with_options(dataset_name, DatasetRefreshRequest::default())
+            .await
+    }
+
+    /// Triggers an on-demand refresh for an accelerated dataset with overrides.
+    ///
+    /// **Note:** Requires [`http_url()`](SpiceClientBuilder::http_url) to be configured.
+    pub async fn refresh_dataset_with_options(
+        &self,
+        dataset_name: &str,
+        request: DatasetRefreshRequest,
+    ) -> Result<DatasetRefreshResponse, DatasetError> {
+        let http_client = self.http_client.as_ref().ok_or(DatasetError::HttpError {
+            dataset_name: dataset_name.to_string(),
+            message: "HTTP endpoint not configured. Use ClientBuilder::http_url() to set it."
+                .to_string(),
+        })?;
+
+        http_client.refresh_dataset(dataset_name, &request).await
+    }
 }
 
 /// Builder for creating a `SpiceClient`.
@@ -472,9 +560,9 @@ impl SpiceClientBuilder {
         self
     }
 
-    /// Configures the HTTP endpoint for async query API (`/v1/queries`).
+    /// Configures the HTTP endpoint for runtime HTTP APIs.
     ///
-    /// This endpoint is required for using the async [`SpiceClient::query()`] method.
+    /// This endpoint is required for using async query management and dataset refresh APIs.
     /// Typically this is `http://localhost:8090` for local development or the
     /// HTTP API endpoint for your Spice.ai cluster.
     #[must_use]

--- a/src/client.rs
+++ b/src/client.rs
@@ -603,6 +603,54 @@ impl SpiceClientBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dataset::DatasetRefreshMode;
+    use crate::query::QueryStatus;
+    use arrow::array::Int32Array;
+    use futures::TryStreamExt;
+    use serde_json::json;
+    use std::time::Duration;
+    use tonic::transport::Endpoint;
+    use wiremock::matchers::{body_json, method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_client(http_base_url: Option<&str>) -> SpiceClient {
+        let flight_channel = Endpoint::from_static("http://127.0.0.1:50051").connect_lazy();
+
+        SpiceClient {
+            flight: Arc::new(SqlFlightClient::new(
+                flight_channel,
+                None,
+                None,
+                None,
+                MAX_RETRIES,
+            )),
+            http_client: http_base_url
+                .map(|base_url| Arc::new(QueryHttpClient::new(base_url, None))),
+        }
+    }
+
+    fn query_manifest_response(query_id: &str, status: QueryStatus) -> serde_json::Value {
+        json!({
+            "query_id": query_id,
+            "status": status,
+            "manifest": {
+                "format": "json",
+                "schema": {
+                    "column_count": 1,
+                    "columns": [
+                        {
+                            "name": "answer",
+                            "type_name": "Int32",
+                            "nullable": false,
+                            "position": 0
+                        }
+                    ]
+                },
+                "total_row_count": 2,
+                "total_chunk_count": 1
+            }
+        })
+    }
 
     #[test]
     fn test_client_builder_default() {
@@ -826,5 +874,268 @@ mod tests {
             .user_agent("  agent  ");
         assert_eq!(builder.api_key, Some("  key with spaces  ".to_string()));
         assert_eq!(builder.user_agent, Some("  agent  ".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_async_methods_require_http_url() {
+        let client = test_client(None);
+
+        assert!(matches!(
+            client.query("SELECT 1").await,
+            Err(QueryError::HttpError { .. })
+        ));
+        assert!(matches!(
+            client.queries(None, None).await,
+            Err(QueryError::HttpError { .. })
+        ));
+        assert!(matches!(
+            client.get_query("qry_123"),
+            Err(QueryError::HttpError { .. })
+        ));
+        assert!(matches!(
+            client.cancel_query("qry_123").await,
+            Err(QueryError::HttpError { .. })
+        ));
+        assert!(matches!(
+            client.refresh_dataset("orders").await,
+            Err(DatasetError::HttpError { .. })
+        ));
+        assert!(matches!(
+            client
+                .refresh_dataset_with_options(
+                    "orders",
+                    DatasetRefreshRequest::new().with_refresh_mode(DatasetRefreshMode::Append),
+                )
+                .await,
+            Err(DatasetError::HttpError { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_async_query_wrappers_and_job_lifecycle() {
+        let server = MockServer::start().await;
+        let query_id = "qry_123";
+
+        Mock::given(method("POST"))
+            .and(path("/v1/queries"))
+            .and(body_json(json!({ "sql": "SELECT 1" })))
+            .respond_with(
+                ResponseTemplate::new(202).set_body_json(json!({
+                    "query_id": query_id,
+                    "status": "PENDING",
+                    "status_url": format!("{}/v1/queries/{query_id}/status", server.uri()),
+                    "results_url": format!("{}/v1/queries/{query_id}/results", server.uri())
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/queries"))
+            .and(query_param("status", "running"))
+            .and(query_param("limit", "5"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "queries": [
+                        {
+                            "query_id": query_id,
+                            "status": "RUNNING",
+                            "created_at": "2025-01-01T00:00:00Z",
+                            "sql_preview": "SELECT 1"
+                        }
+                    ],
+                    "total_count": 1
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/queries/{query_id}/status")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "status": "RUNNING"
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/queries/{query_id}")))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(query_manifest_response(
+                    query_id,
+                    QueryStatus::Succeeded,
+                )),
+            )
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/queries/{query_id}/results/chunks/0")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "chunk_index": 0,
+                "row_offset": 0,
+                "row_count": 2,
+                "data_array": [
+                    { "answer": 1 },
+                    { "answer": 2 }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path(format!("/v1/queries/{query_id}/cancel")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "query_id": query_id,
+                "status": "CANCELLED"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(Some(&server.uri()));
+
+        let queries = client
+            .queries(Some("running"), Some(5))
+            .await
+            .expect("list async queries");
+        assert_eq!(queries.total_count, Some(1));
+        assert_eq!(queries.queries.len(), 1);
+        assert_eq!(queries.queries[0].query_id, query_id);
+        assert_eq!(queries.queries[0].status, QueryStatus::Running);
+
+        let job = client.query("SELECT 1").await.expect("submit async query");
+        assert_eq!(job.id(), query_id);
+        assert_eq!(job.status().await.expect("get query status"), QueryStatus::Running);
+
+        let info = job.info().await.expect("get query info");
+        assert_eq!(info.query_id, query_id);
+        assert_eq!(info.status, QueryStatus::Succeeded);
+        let info_result = info.result.expect("query result metadata");
+        assert_eq!(info_result.total_rows, 2);
+        assert_eq!(info_result.total_chunks, 1);
+
+        let wait_result = job.wait().await.expect("wait for query completion");
+        assert_eq!(wait_result.total_rows, 2);
+        assert_eq!(wait_result.total_chunks, 1);
+
+        let wait_timeout_result = client
+            .get_query(query_id)
+            .expect("resume query handle")
+            .with_poll_interval(Duration::from_millis(1))
+            .wait_timeout(Duration::from_millis(10))
+            .await
+            .expect("wait for query completion with timeout");
+        assert_eq!(wait_timeout_result.total_rows, 2);
+
+        let batches = client
+            .get_query(query_id)
+            .expect("resume query handle")
+            .results()
+            .await
+            .expect("fetch query results");
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].num_rows(), 2);
+        let answers = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("downcast answer column to Int32Array");
+        assert_eq!(answers.value(0), 1);
+        assert_eq!(answers.value(1), 2);
+
+        let streamed_batches = client
+            .get_query(query_id)
+            .expect("resume query handle")
+            .results_stream()
+            .await
+            .expect("stream query results")
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("collect streamed query results");
+        assert_eq!(streamed_batches.len(), 1);
+        assert_eq!(streamed_batches[0].num_rows(), 2);
+
+        let cancelled = job.cancel().await.expect("cancel query from job handle");
+        assert_eq!(cancelled.query_id, query_id);
+        assert_eq!(cancelled.status, QueryStatus::Cancelled);
+
+        let cancelled_via_client = client
+            .cancel_query(query_id)
+            .await
+            .expect("cancel query from client wrapper");
+        assert_eq!(cancelled_via_client.query_id, query_id);
+        assert_eq!(cancelled_via_client.status, QueryStatus::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn test_query_job_wait_timeout_returns_timeout_for_running_query() {
+        let server = MockServer::start().await;
+        let query_id = "qry_timeout";
+
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/queries/{query_id}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "query_id": query_id,
+                "status": "RUNNING"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(Some(&server.uri()));
+        let err = client
+            .get_query(query_id)
+            .expect("create query handle")
+            .with_poll_interval(Duration::from_millis(1))
+            .wait_timeout(Duration::from_millis(5))
+            .await
+            .expect_err("query wait should time out while still running");
+
+        assert!(matches!(err, QueryError::Timeout { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_refresh_dataset_wrappers() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/datasets/orders_default/acceleration/refresh"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "message": "Refresh started"
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/datasets/orders_custom/acceleration/refresh"))
+            .and(body_json(json!({
+                "refresh_sql": "SELECT * FROM orders",
+                "refresh_mode": "append",
+                "refresh_jitter_max": "30s"
+            })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+                "message": "Refresh scheduled"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(Some(&server.uri()));
+
+        let default_refresh = client
+            .refresh_dataset("orders_default")
+            .await
+            .expect("refresh dataset with default settings");
+        assert_eq!(default_refresh.message, "Refresh started");
+
+        let custom_refresh = client
+            .refresh_dataset_with_options(
+                "orders_custom",
+                DatasetRefreshRequest::new()
+                    .with_refresh_sql("SELECT * FROM orders")
+                    .with_refresh_mode(DatasetRefreshMode::Append)
+                    .with_refresh_jitter_max("30s"),
+            )
+            .await
+            .expect("refresh dataset with explicit overrides");
+        assert_eq!(custom_refresh.message, "Refresh scheduled");
     }
 }

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -1,0 +1,123 @@
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+pub enum DatasetError {
+    #[snafu(display("Dataset not found: {dataset_name}"))]
+    NotFound { dataset_name: String },
+
+    #[snafu(display("Dataset {dataset_name} does not have acceleration enabled"))]
+    AccelerationNotEnabled { dataset_name: String },
+
+    #[snafu(display(
+        "Failed to refresh dataset {dataset_name} (HTTP {status_code}): {response_body}"
+    ))]
+    RefreshFailed {
+        dataset_name: String,
+        status_code: u16,
+        response_body: String,
+    },
+
+    #[snafu(display("Failed to refresh dataset {dataset_name}: {message}"))]
+    HttpError {
+        dataset_name: String,
+        message: String,
+    },
+
+    #[snafu(display("Failed to parse dataset response for {dataset_name}: {message}"))]
+    ParseError {
+        dataset_name: String,
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DatasetRefreshMode {
+    Full,
+    Append,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct DatasetRefreshRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_mode: Option<DatasetRefreshMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_jitter_max: Option<String>,
+}
+
+impl DatasetRefreshRequest {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn with_refresh_sql(mut self, refresh_sql: impl Into<String>) -> Self {
+        self.refresh_sql = Some(refresh_sql.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_refresh_mode(mut self, refresh_mode: DatasetRefreshMode) -> Self {
+        self.refresh_mode = Some(refresh_mode);
+        self
+    }
+
+    #[must_use]
+    pub fn with_refresh_jitter_max(mut self, refresh_jitter_max: impl Into<String>) -> Self {
+        self.refresh_jitter_max = Some(refresh_jitter_max.into());
+        self
+    }
+
+    pub(crate) fn has_overrides(&self) -> bool {
+        self.refresh_sql.is_some()
+            || self.refresh_mode.is_some()
+            || self.refresh_jitter_max.is_some()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct DatasetRefreshResponse {
+    pub message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_refresh_request_default_has_no_overrides() {
+        let request = DatasetRefreshRequest::new();
+        assert!(!request.has_overrides());
+    }
+
+    #[test]
+    fn test_refresh_request_builder() {
+        let request = DatasetRefreshRequest::new()
+            .with_refresh_sql("SELECT * FROM taxi_trips")
+            .with_refresh_mode(DatasetRefreshMode::Full)
+            .with_refresh_jitter_max("30s");
+
+        assert!(request.has_overrides());
+        assert_eq!(
+            request.refresh_sql.as_deref(),
+            Some("SELECT * FROM taxi_trips")
+        );
+        assert_eq!(request.refresh_mode, Some(DatasetRefreshMode::Full));
+        assert_eq!(request.refresh_jitter_max.as_deref(), Some("30s"));
+    }
+
+    #[test]
+    fn test_refresh_mode_serialization() {
+        let serialized =
+            serde_json::to_string(&DatasetRefreshMode::Append).expect("serialize refresh mode");
+        assert_eq!(serialized, "\"append\"");
+
+        let deserialized: DatasetRefreshMode =
+            serde_json::from_str("\"full\"").expect("deserialize refresh mode");
+        assert_eq!(deserialized, DatasetRefreshMode::Full);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,21 @@
 
 mod client;
 mod config;
+mod dataset;
 mod flight;
+mod params;
 pub mod query;
 mod tls;
 mod util;
 
+pub use arrow;
 pub use client::Error as SpiceClientError;
 pub use client::SpiceClient as Client;
 pub use client::SpiceClientBuilder as ClientBuilder;
+pub use dataset::{
+    DatasetError, DatasetRefreshMode, DatasetRefreshRequest, DatasetRefreshResponse,
+};
+pub use params::{QueryParameter, QueryParameterError, QueryParameters};
 pub use query::{
     QueryError, QueryInfo, QueryJob, QueryListResponse, QueryResult, QueryResultStream,
     QueryStatus, QuerySummary,

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,0 +1,399 @@
+use arrow::array::{
+    ArrayRef, BinaryArray, BooleanArray, Float32Array, Float64Array, Int8Array, Int16Array,
+    Int32Array, Int64Array, LargeBinaryArray, LargeStringArray, StringArray, UInt8Array,
+    UInt16Array, UInt32Array, UInt64Array, new_null_array,
+};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::error::ArrowError;
+use arrow::record_batch::RecordBatch;
+use snafu::Snafu;
+use std::sync::Arc;
+
+#[derive(Debug, Snafu)]
+pub enum QueryParameterError {
+    #[snafu(display("Failed to construct query parameter batch: {source}"))]
+    BatchCreation { source: ArrowError },
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct QueryParameters {
+    values: Vec<QueryParameter>,
+}
+
+impl QueryParameters {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn push(mut self, value: impl Into<QueryParameter>) -> Self {
+        self.values.push(value.into());
+        self
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    pub fn into_record_batch(self) -> Result<Option<RecordBatch>, QueryParameterError> {
+        if self.values.is_empty() {
+            return Ok(None);
+        }
+
+        let (fields, columns): (Vec<_>, Vec<_>) = self
+            .values
+            .into_iter()
+            .enumerate()
+            .map(|(index, value)| value.into_field_and_array(index))
+            .unzip();
+
+        RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
+            .map(Some)
+            .map_err(|source| QueryParameterError::BatchCreation { source })
+    }
+}
+
+impl From<QueryParameter> for QueryParameters {
+    fn from(value: QueryParameter) -> Self {
+        Self {
+            values: vec![value],
+        }
+    }
+}
+
+impl From<Vec<QueryParameter>> for QueryParameters {
+    fn from(values: Vec<QueryParameter>) -> Self {
+        Self { values }
+    }
+}
+
+impl<const N: usize> From<[QueryParameter; N]> for QueryParameters {
+    fn from(values: [QueryParameter; N]) -> Self {
+        values.into_iter().collect()
+    }
+}
+
+impl FromIterator<QueryParameter> for QueryParameters {
+    fn from_iter<T: IntoIterator<Item = QueryParameter>>(iter: T) -> Self {
+        Self {
+            values: iter.into_iter().collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum QueryParameter {
+    Boolean(Option<bool>),
+    Int8(Option<i8>),
+    Int16(Option<i16>),
+    Int32(Option<i32>),
+    Int64(Option<i64>),
+    UInt8(Option<u8>),
+    UInt16(Option<u16>),
+    UInt32(Option<u32>),
+    UInt64(Option<u64>),
+    Float32(Option<f32>),
+    Float64(Option<f64>),
+    Utf8(Option<String>),
+    LargeUtf8(Option<String>),
+    Binary(Option<Vec<u8>>),
+    LargeBinary(Option<Vec<u8>>),
+    Null(DataType),
+}
+
+impl QueryParameter {
+    #[must_use]
+    pub fn null(data_type: DataType) -> Self {
+        Self::Null(data_type)
+    }
+
+    fn into_field_and_array(self, index: usize) -> (Field, ArrayRef) {
+        let field_name = format!("${}", index + 1);
+        let data_type = self.data_type();
+        let array = self.into_array();
+        (Field::new(&field_name, data_type, true), array)
+    }
+
+    fn data_type(&self) -> DataType {
+        match self {
+            Self::Boolean(_) => DataType::Boolean,
+            Self::Int8(_) => DataType::Int8,
+            Self::Int16(_) => DataType::Int16,
+            Self::Int32(_) => DataType::Int32,
+            Self::Int64(_) => DataType::Int64,
+            Self::UInt8(_) => DataType::UInt8,
+            Self::UInt16(_) => DataType::UInt16,
+            Self::UInt32(_) => DataType::UInt32,
+            Self::UInt64(_) => DataType::UInt64,
+            Self::Float32(_) => DataType::Float32,
+            Self::Float64(_) => DataType::Float64,
+            Self::Utf8(_) => DataType::Utf8,
+            Self::LargeUtf8(_) => DataType::LargeUtf8,
+            Self::Binary(_) => DataType::Binary,
+            Self::LargeBinary(_) => DataType::LargeBinary,
+            Self::Null(data_type) => data_type.clone(),
+        }
+    }
+
+    fn into_array(self) -> ArrayRef {
+        match self {
+            Self::Boolean(value) => Arc::new(BooleanArray::from(vec![value])) as ArrayRef,
+            Self::Int8(value) => Arc::new(Int8Array::from(vec![value])) as ArrayRef,
+            Self::Int16(value) => Arc::new(Int16Array::from(vec![value])) as ArrayRef,
+            Self::Int32(value) => Arc::new(Int32Array::from(vec![value])) as ArrayRef,
+            Self::Int64(value) => Arc::new(Int64Array::from(vec![value])) as ArrayRef,
+            Self::UInt8(value) => Arc::new(UInt8Array::from(vec![value])) as ArrayRef,
+            Self::UInt16(value) => Arc::new(UInt16Array::from(vec![value])) as ArrayRef,
+            Self::UInt32(value) => Arc::new(UInt32Array::from(vec![value])) as ArrayRef,
+            Self::UInt64(value) => Arc::new(UInt64Array::from(vec![value])) as ArrayRef,
+            Self::Float32(value) => Arc::new(Float32Array::from(vec![value])) as ArrayRef,
+            Self::Float64(value) => Arc::new(Float64Array::from(vec![value])) as ArrayRef,
+            Self::Utf8(value) => Arc::new(StringArray::from(vec![value.as_deref()])) as ArrayRef,
+            Self::LargeUtf8(value) => {
+                Arc::new(LargeStringArray::from(vec![value.as_deref()])) as ArrayRef
+            }
+            Self::Binary(value) => Arc::new(BinaryArray::from(vec![value.as_deref()])) as ArrayRef,
+            Self::LargeBinary(value) => {
+                Arc::new(LargeBinaryArray::from(vec![value.as_deref()])) as ArrayRef
+            }
+            Self::Null(data_type) => new_null_array(&data_type, 1),
+        }
+    }
+}
+
+impl From<bool> for QueryParameter {
+    fn from(value: bool) -> Self {
+        Self::Boolean(Some(value))
+    }
+}
+
+impl From<Option<bool>> for QueryParameter {
+    fn from(value: Option<bool>) -> Self {
+        Self::Boolean(value)
+    }
+}
+
+impl From<i8> for QueryParameter {
+    fn from(value: i8) -> Self {
+        Self::Int8(Some(value))
+    }
+}
+
+impl From<Option<i8>> for QueryParameter {
+    fn from(value: Option<i8>) -> Self {
+        Self::Int8(value)
+    }
+}
+
+impl From<i16> for QueryParameter {
+    fn from(value: i16) -> Self {
+        Self::Int16(Some(value))
+    }
+}
+
+impl From<Option<i16>> for QueryParameter {
+    fn from(value: Option<i16>) -> Self {
+        Self::Int16(value)
+    }
+}
+
+impl From<i32> for QueryParameter {
+    fn from(value: i32) -> Self {
+        Self::Int32(Some(value))
+    }
+}
+
+impl From<Option<i32>> for QueryParameter {
+    fn from(value: Option<i32>) -> Self {
+        Self::Int32(value)
+    }
+}
+
+impl From<i64> for QueryParameter {
+    fn from(value: i64) -> Self {
+        Self::Int64(Some(value))
+    }
+}
+
+impl From<Option<i64>> for QueryParameter {
+    fn from(value: Option<i64>) -> Self {
+        Self::Int64(value)
+    }
+}
+
+impl From<u8> for QueryParameter {
+    fn from(value: u8) -> Self {
+        Self::UInt8(Some(value))
+    }
+}
+
+impl From<Option<u8>> for QueryParameter {
+    fn from(value: Option<u8>) -> Self {
+        Self::UInt8(value)
+    }
+}
+
+impl From<u16> for QueryParameter {
+    fn from(value: u16) -> Self {
+        Self::UInt16(Some(value))
+    }
+}
+
+impl From<Option<u16>> for QueryParameter {
+    fn from(value: Option<u16>) -> Self {
+        Self::UInt16(value)
+    }
+}
+
+impl From<u32> for QueryParameter {
+    fn from(value: u32) -> Self {
+        Self::UInt32(Some(value))
+    }
+}
+
+impl From<Option<u32>> for QueryParameter {
+    fn from(value: Option<u32>) -> Self {
+        Self::UInt32(value)
+    }
+}
+
+impl From<u64> for QueryParameter {
+    fn from(value: u64) -> Self {
+        Self::UInt64(Some(value))
+    }
+}
+
+impl From<Option<u64>> for QueryParameter {
+    fn from(value: Option<u64>) -> Self {
+        Self::UInt64(value)
+    }
+}
+
+impl From<f32> for QueryParameter {
+    fn from(value: f32) -> Self {
+        Self::Float32(Some(value))
+    }
+}
+
+impl From<Option<f32>> for QueryParameter {
+    fn from(value: Option<f32>) -> Self {
+        Self::Float32(value)
+    }
+}
+
+impl From<f64> for QueryParameter {
+    fn from(value: f64) -> Self {
+        Self::Float64(Some(value))
+    }
+}
+
+impl From<Option<f64>> for QueryParameter {
+    fn from(value: Option<f64>) -> Self {
+        Self::Float64(value)
+    }
+}
+
+impl From<String> for QueryParameter {
+    fn from(value: String) -> Self {
+        Self::Utf8(Some(value))
+    }
+}
+
+impl From<Option<String>> for QueryParameter {
+    fn from(value: Option<String>) -> Self {
+        Self::Utf8(value)
+    }
+}
+
+impl<'a> From<&'a str> for QueryParameter {
+    fn from(value: &'a str) -> Self {
+        Self::Utf8(Some(value.to_string()))
+    }
+}
+
+impl<'a> From<Option<&'a str>> for QueryParameter {
+    fn from(value: Option<&'a str>) -> Self {
+        Self::Utf8(value.map(str::to_string))
+    }
+}
+
+impl From<Vec<u8>> for QueryParameter {
+    fn from(value: Vec<u8>) -> Self {
+        Self::Binary(Some(value))
+    }
+}
+
+impl From<Option<Vec<u8>>> for QueryParameter {
+    fn from(value: Option<Vec<u8>>) -> Self {
+        Self::Binary(value)
+    }
+}
+
+impl<'a> From<&'a [u8]> for QueryParameter {
+    fn from(value: &'a [u8]) -> Self {
+        Self::Binary(Some(value.to_vec()))
+    }
+}
+
+impl<'a> From<Option<&'a [u8]>> for QueryParameter {
+    fn from(value: Option<&'a [u8]>) -> Self {
+        Self::Binary(value.map(<[u8]>::to_vec))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Int32Array, StringArray};
+
+    #[test]
+    fn test_query_parameters_build_record_batch() {
+        let batch = QueryParameters::new()
+            .push(1_i32)
+            .push(1.5_f64)
+            .push("taxi")
+            .into_record_batch()
+            .expect("parameter batch should be created")
+            .expect("parameter batch should not be empty");
+
+        assert_eq!(batch.schema().field(0).name(), "$1");
+        assert_eq!(batch.schema().field(1).name(), "$2");
+        assert_eq!(batch.schema().field(2).name(), "$3");
+
+        let int_values = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("$1 should be Int32");
+        assert_eq!(int_values.value(0), 1);
+
+        let text_values = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("$3 should be Utf8");
+        assert_eq!(text_values.value(0), "taxi");
+    }
+
+    #[test]
+    fn test_query_parameters_empty_batch() {
+        let batch = QueryParameters::new()
+            .into_record_batch()
+            .expect("empty parameter batch should succeed");
+        assert!(batch.is_none());
+    }
+
+    #[test]
+    fn test_query_parameters_typed_null() {
+        let batch = QueryParameters::new()
+            .push(QueryParameter::null(DataType::Int32))
+            .into_record_batch()
+            .expect("typed null batch should be created")
+            .expect("typed null batch should not be empty");
+
+        assert_eq!(batch.schema().field(0).data_type(), &DataType::Int32);
+        assert!(batch.column(0).is_null(0));
+    }
+}

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,18 +1,23 @@
 use arrow::array::{
-    ArrayRef, BinaryArray, BooleanArray, Float32Array, Float64Array, Int8Array, Int16Array,
-    Int32Array, Int64Array, LargeBinaryArray, LargeStringArray, StringArray, UInt8Array,
-    UInt16Array, UInt32Array, UInt64Array, new_null_array,
+    Array, ArrayRef, BinaryArray, BooleanArray, Float32Array, Float64Array, Int8Array,
+    Int16Array, Int32Array, Int64Array, LargeBinaryArray, LargeStringArray, StringArray,
+    UInt8Array, UInt16Array, UInt32Array, UInt64Array, new_null_array,
 };
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
-use snafu::Snafu;
+use snafu::{Snafu, ensure};
 use std::sync::Arc;
 
 #[derive(Debug, Snafu)]
 pub enum QueryParameterError {
     #[snafu(display("Failed to construct query parameter batch: {source}"))]
     BatchCreation { source: ArrowError },
+
+    #[snafu(display(
+        "Query parameter arrays must contain exactly one value, got {array_length}"
+    ))]
+    InvalidArrayLength { array_length: usize },
 }
 
 #[derive(Debug, Clone, Default)]
@@ -42,12 +47,14 @@ impl QueryParameters {
             return Ok(None);
         }
 
-        let (fields, columns): (Vec<_>, Vec<_>) = self
+        let field_arrays = self
             .values
             .into_iter()
             .enumerate()
             .map(|(index, value)| value.into_field_and_array(index))
-            .unzip();
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let (fields, columns): (Vec<_>, Vec<_>) = field_arrays.into_iter().unzip();
 
         RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
             .map(Some)
@@ -100,6 +107,7 @@ pub enum QueryParameter {
     LargeUtf8(Option<String>),
     Binary(Option<Vec<u8>>),
     LargeBinary(Option<Vec<u8>>),
+    Array(ArrayRef),
     Null(DataType),
 }
 
@@ -109,11 +117,34 @@ impl QueryParameter {
         Self::Null(data_type)
     }
 
-    fn into_field_and_array(self, index: usize) -> (Field, ArrayRef) {
+    pub fn array<A>(array: A) -> Result<Self, QueryParameterError>
+    where
+        A: Array + 'static,
+    {
+        Self::array_ref(Arc::new(array) as ArrayRef)
+    }
+
+    pub fn array_ref(array: ArrayRef) -> Result<Self, QueryParameterError> {
+        ensure!(
+            array.len() == 1,
+            InvalidArrayLengthSnafu {
+                array_length: array.len(),
+            }
+        );
+        Ok(Self::Array(array))
+    }
+
+    fn into_field_and_array(self, index: usize) -> Result<(Field, ArrayRef), QueryParameterError> {
         let field_name = format!("${}", index + 1);
         let data_type = self.data_type();
         let array = self.into_array();
-        (Field::new(&field_name, data_type, true), array)
+        ensure!(
+            array.len() == 1,
+            InvalidArrayLengthSnafu {
+                array_length: array.len(),
+            }
+        );
+        Ok((Field::new(&field_name, data_type, true), array))
     }
 
     fn data_type(&self) -> DataType {
@@ -133,6 +164,7 @@ impl QueryParameter {
             Self::LargeUtf8(_) => DataType::LargeUtf8,
             Self::Binary(_) => DataType::Binary,
             Self::LargeBinary(_) => DataType::LargeBinary,
+            Self::Array(array) => array.data_type().clone(),
             Self::Null(data_type) => data_type.clone(),
         }
     }
@@ -158,8 +190,17 @@ impl QueryParameter {
             Self::LargeBinary(value) => {
                 Arc::new(LargeBinaryArray::from(vec![value.as_deref()])) as ArrayRef
             }
+            Self::Array(array) => array,
             Self::Null(data_type) => new_null_array(&data_type, 1),
         }
+    }
+}
+
+impl TryFrom<ArrayRef> for QueryParameter {
+    type Error = QueryParameterError;
+
+    fn try_from(value: ArrayRef) -> Result<Self, Self::Error> {
+        Self::array_ref(value)
     }
 }
 
@@ -346,7 +387,112 @@ impl<'a> From<Option<&'a [u8]>> for QueryParameter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Int32Array, StringArray};
+    use arrow::array::{
+        ArrayRef, BinaryArray, BinaryViewArray, BooleanArray, Date32Array, Date64Array,
+        Decimal128Array, Float32Array, Float64Array, Int8Array, Int16Array, Int32Array,
+        Int32DictionaryArray, Int64Array, LargeBinaryArray, LargeStringArray, StringArray,
+        StringViewArray, TimestampNanosecondArray, UInt8Array, UInt16Array, UInt32Array,
+        UInt64Array, new_null_array,
+    };
+    use arrow::datatypes::{IntervalUnit, TimeUnit, UnionFields, UnionMode};
+    use std::sync::Arc;
+
+    fn batch_from(params: QueryParameters) -> RecordBatch {
+        params
+            .into_record_batch()
+            .expect("parameter batch should be created")
+            .expect("parameter batch should not be empty")
+    }
+
+    fn full_arrow_data_types() -> Vec<DataType> {
+        let list_field = Arc::new(Field::new_list_field(DataType::Int32, true));
+        let large_list_field = Arc::new(Field::new_list_field(DataType::Int64, true));
+        let fixed_size_list_field = Arc::new(Field::new_list_field(DataType::Int16, true));
+        let struct_fields = vec![
+            Arc::new(Field::new("int_field", DataType::Int32, true)),
+            Arc::new(Field::new("text_field", DataType::Utf8, true)),
+        ];
+        let union_fields = UnionFields::try_new(
+            vec![0, 1],
+            vec![
+                Field::new("union_int", DataType::Int32, true),
+                Field::new("union_text", DataType::Utf8, true),
+            ],
+        )
+        .expect("union fields should be valid");
+        let map_entries = Arc::new(Field::new(
+            "entries",
+            DataType::Struct(
+                vec![
+                    Arc::new(Field::new("key", DataType::Utf8, false)),
+                    Arc::new(Field::new("value", DataType::Int32, true)),
+                ]
+                .into(),
+            ),
+            false,
+        ));
+        let run_end_type = Arc::new(Field::new("run_ends", DataType::Int32, false));
+        let run_value_type = Arc::new(Field::new("values", DataType::Utf8, true));
+
+        vec![
+            DataType::Null,
+            DataType::Boolean,
+            DataType::Int8,
+            DataType::Int16,
+            DataType::Int32,
+            DataType::Int64,
+            DataType::UInt8,
+            DataType::UInt16,
+            DataType::UInt32,
+            DataType::UInt64,
+            DataType::Float16,
+            DataType::Float32,
+            DataType::Float64,
+            DataType::Timestamp(TimeUnit::Second, None),
+            DataType::Timestamp(TimeUnit::Millisecond, Some("+00:00".into())),
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            DataType::Timestamp(TimeUnit::Nanosecond, Some("+00:00".into())),
+            DataType::Date32,
+            DataType::Date64,
+            DataType::Time32(TimeUnit::Second),
+            DataType::Time32(TimeUnit::Millisecond),
+            DataType::Time64(TimeUnit::Microsecond),
+            DataType::Time64(TimeUnit::Nanosecond),
+            DataType::Duration(TimeUnit::Second),
+            DataType::Duration(TimeUnit::Millisecond),
+            DataType::Duration(TimeUnit::Microsecond),
+            DataType::Duration(TimeUnit::Nanosecond),
+            DataType::Interval(IntervalUnit::YearMonth),
+            DataType::Interval(IntervalUnit::DayTime),
+            DataType::Interval(IntervalUnit::MonthDayNano),
+            DataType::Binary,
+            DataType::FixedSizeBinary(4),
+            DataType::LargeBinary,
+            DataType::BinaryView,
+            DataType::Utf8,
+            DataType::LargeUtf8,
+            DataType::Utf8View,
+            DataType::List(Arc::clone(&list_field)),
+            DataType::ListView(Arc::clone(&list_field)),
+            DataType::FixedSizeList(Arc::clone(&fixed_size_list_field), 2),
+            DataType::LargeList(Arc::clone(&large_list_field)),
+            DataType::LargeListView(Arc::clone(&large_list_field)),
+            DataType::Struct(struct_fields.clone().into()),
+            DataType::Union(union_fields.clone(), UnionMode::Sparse),
+            DataType::Union(union_fields, UnionMode::Dense),
+            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+            DataType::Decimal32(5, 2),
+            DataType::Decimal64(10, 2),
+            DataType::Decimal128(20, 2),
+            DataType::Decimal256(40, 2),
+            DataType::Map(map_entries, false),
+            DataType::RunEndEncoded(run_end_type, run_value_type),
+        ]
+    }
+
+    fn array_parameter(array: ArrayRef) -> QueryParameter {
+        QueryParameter::array_ref(array).expect("array-backed parameter should be valid")
+    }
 
     #[test]
     fn test_query_parameters_build_record_batch() {
@@ -378,6 +524,507 @@ mod tests {
     }
 
     #[test]
+    fn test_query_parameters_cover_supported_scalar_types() {
+        let batch = batch_from(
+            QueryParameters::new()
+                .push(true)
+                .push(-8_i8)
+                .push(-16_i16)
+                .push(-32_i32)
+                .push(-64_i64)
+                .push(8_u8)
+                .push(16_u16)
+                .push(32_u32)
+                .push(64_u64)
+                .push(3.25_f32)
+                .push(6.5_f64)
+                .push(String::from("utf8-owned"))
+                .push(QueryParameter::LargeUtf8(Some("large-utf8".to_string())))
+                .push(vec![1_u8, 2, 3])
+                .push(QueryParameter::LargeBinary(Some(vec![4_u8, 5, 6]))),
+        );
+
+        let expected_types = vec![
+            DataType::Boolean,
+            DataType::Int8,
+            DataType::Int16,
+            DataType::Int32,
+            DataType::Int64,
+            DataType::UInt8,
+            DataType::UInt16,
+            DataType::UInt32,
+            DataType::UInt64,
+            DataType::Float32,
+            DataType::Float64,
+            DataType::Utf8,
+            DataType::LargeUtf8,
+            DataType::Binary,
+            DataType::LargeBinary,
+        ];
+        let schema = batch.schema();
+
+        for (index, data_type) in expected_types.iter().enumerate() {
+            let expected_name = format!("${}", index + 1);
+            let field = schema.field(index);
+            assert_eq!(field.name(), expected_name.as_str());
+            assert_eq!(field.data_type(), data_type);
+        }
+
+        assert!(batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .expect("$1 should be Boolean")
+            .value(0));
+        assert_eq!(
+            batch.column(1)
+                .as_any()
+                .downcast_ref::<Int8Array>()
+                .expect("$2 should be Int8")
+                .value(0),
+            -8
+        );
+        assert_eq!(
+            batch.column(2)
+                .as_any()
+                .downcast_ref::<Int16Array>()
+                .expect("$3 should be Int16")
+                .value(0),
+            -16
+        );
+        assert_eq!(
+            batch.column(3)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .expect("$4 should be Int32")
+                .value(0),
+            -32
+        );
+        assert_eq!(
+            batch.column(4)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("$5 should be Int64")
+                .value(0),
+            -64
+        );
+        assert_eq!(
+            batch.column(5)
+                .as_any()
+                .downcast_ref::<UInt8Array>()
+                .expect("$6 should be UInt8")
+                .value(0),
+            8
+        );
+        assert_eq!(
+            batch.column(6)
+                .as_any()
+                .downcast_ref::<UInt16Array>()
+                .expect("$7 should be UInt16")
+                .value(0),
+            16
+        );
+        assert_eq!(
+            batch.column(7)
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .expect("$8 should be UInt32")
+                .value(0),
+            32
+        );
+        assert_eq!(
+            batch.column(8)
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .expect("$9 should be UInt64")
+                .value(0),
+            64
+        );
+        assert_eq!(
+            batch.column(9)
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .expect("$10 should be Float32")
+                .value(0),
+            3.25
+        );
+        assert_eq!(
+            batch.column(10)
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .expect("$11 should be Float64")
+                .value(0),
+            6.5
+        );
+        assert_eq!(
+            batch.column(11)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("$12 should be Utf8")
+                .value(0),
+            "utf8-owned"
+        );
+        assert_eq!(
+            batch.column(12)
+                .as_any()
+                .downcast_ref::<LargeStringArray>()
+                .expect("$13 should be LargeUtf8")
+                .value(0),
+            "large-utf8"
+        );
+        assert_eq!(
+            batch.column(13)
+                .as_any()
+                .downcast_ref::<BinaryArray>()
+                .expect("$14 should be Binary")
+                .value(0),
+            &[1_u8, 2, 3]
+        );
+        assert_eq!(
+            batch.column(14)
+                .as_any()
+                .downcast_ref::<LargeBinaryArray>()
+                .expect("$15 should be LargeBinary")
+                .value(0),
+            &[4_u8, 5, 6]
+        );
+    }
+
+    #[test]
+    fn test_query_parameter_array_backed_values_preserve_arrow_types() {
+        let decimal = Decimal128Array::from(vec![Some(12_345_i128)])
+            .with_precision_and_scale(5, 2)
+            .expect("decimal array should accept precision and scale");
+        let timestamp = TimestampNanosecondArray::from(vec![Some(1_234_567_890_i64)])
+            .with_timezone_utc();
+        let date = Date32Array::from(vec![Some(19_000)]);
+        let date64 = Date64Array::from(vec![Some(1_728_000_000_i64)]);
+
+        let batch = batch_from(
+            QueryParameters::new()
+                .push(QueryParameter::array(StringViewArray::from(vec![Some("view-value")]))
+                    .expect("StringView parameter should be valid"))
+                .push(QueryParameter::array(BinaryViewArray::from(vec![Some(b"view-bytes".as_slice())]))
+                    .expect("BinaryView parameter should be valid"))
+                .push(QueryParameter::array(decimal).expect("Decimal parameter should be valid"))
+                .push(QueryParameter::array(timestamp).expect("Timestamp parameter should be valid"))
+                .push(QueryParameter::array(date).expect("Date32 parameter should be valid"))
+                .push(QueryParameter::array(date64).expect("Date64 parameter should be valid"))
+                .push(
+                    QueryParameter::array(
+                        Int32DictionaryArray::from_iter(vec![Some("dictionary-value")]),
+                    )
+                    .expect("Dictionary parameter should be valid"),
+                ),
+        );
+
+        assert_eq!(batch.schema().field(0).data_type(), &DataType::Utf8View);
+        assert_eq!(batch.schema().field(1).data_type(), &DataType::BinaryView);
+        assert_eq!(batch.schema().field(2).data_type(), &DataType::Decimal128(5, 2));
+        assert_eq!(
+            batch.schema().field(3).data_type(),
+            &DataType::Timestamp(TimeUnit::Nanosecond, Some("+00:00".into()))
+        );
+        assert_eq!(batch.schema().field(4).data_type(), &DataType::Date32);
+        assert_eq!(batch.schema().field(5).data_type(), &DataType::Date64);
+        assert_eq!(
+            batch.schema().field(6).data_type(),
+            &DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8))
+        );
+
+        assert_eq!(
+            batch.column(0)
+                .as_any()
+                .downcast_ref::<StringViewArray>()
+                .expect("$1 should be Utf8View")
+                .value(0),
+            "view-value"
+        );
+        assert_eq!(
+            batch.column(1)
+                .as_any()
+                .downcast_ref::<BinaryViewArray>()
+                .expect("$2 should be BinaryView")
+                .value(0),
+            b"view-bytes"
+        );
+        assert_eq!(
+            batch.column(2)
+                .as_any()
+                .downcast_ref::<Decimal128Array>()
+                .expect("$3 should be Decimal128")
+                .value(0),
+            12_345_i128
+        );
+        assert_eq!(
+            batch.column(3)
+                .as_any()
+                .downcast_ref::<TimestampNanosecondArray>()
+                .expect("$4 should be TimestampNanosecond")
+                .value(0),
+            1_234_567_890_i64
+        );
+        assert_eq!(
+            batch.column(4)
+                .as_any()
+                .downcast_ref::<Date32Array>()
+                .expect("$5 should be Date32")
+                .value(0),
+            19_000
+        );
+        assert_eq!(
+            batch.column(5)
+                .as_any()
+                .downcast_ref::<Date64Array>()
+                .expect("$6 should be Date64")
+                .value(0),
+            1_728_000_000_i64
+        );
+        let dictionary = batch
+            .column(6)
+            .as_any()
+            .downcast_ref::<Int32DictionaryArray>()
+            .expect("$7 should be Dictionary");
+        assert_eq!(dictionary.keys().value(0), 0);
+        let dictionary_values = dictionary
+            .values()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("dictionary values should be Utf8");
+        assert_eq!(dictionary_values.value(0), "dictionary-value");
+    }
+
+    #[test]
+    fn test_query_parameter_array_backed_nulls_cover_entire_arrow_type_set() {
+        for data_type in full_arrow_data_types() {
+            let batch = batch_from(QueryParameters::from(array_parameter(new_null_array(
+                &data_type,
+                1,
+            ))));
+
+            assert_eq!(batch.num_rows(), 1);
+            assert_eq!(batch.schema().field(0).data_type(), &data_type);
+            assert_eq!(batch.column(0).data_type(), &data_type);
+            assert_eq!(batch.column(0).len(), 1);
+        }
+    }
+
+    #[test]
+    fn test_query_parameter_array_requires_single_element() {
+        let err = QueryParameter::array(StringViewArray::from(vec![Some("one"), Some("two")]))
+            .expect_err("array-backed parameters should reject multi-value arrays");
+
+        assert!(matches!(
+            err,
+            QueryParameterError::InvalidArrayLength { array_length: 2 }
+        ));
+
+        let err = QueryParameters::from(QueryParameter::Array(
+            Arc::new(StringArray::from(vec![Some("one"), Some("two")])) as ArrayRef,
+        ))
+        .into_record_batch()
+        .expect_err("direct array variant should also reject multi-value arrays");
+        assert!(matches!(
+            err,
+            QueryParameterError::InvalidArrayLength { array_length: 2 }
+        ));
+    }
+
+    #[test]
+    fn test_query_parameters_option_and_borrowed_bindings() {
+        let borrowed_bytes: &[u8] = b"borrowed-bytes";
+
+        let batch = batch_from(
+            QueryParameters::new()
+                .push(Some(false))
+                .push(None::<i8>)
+                .push(Some(-16_i16))
+                .push(None::<i32>)
+                .push(Some(-64_i64))
+                .push(None::<u8>)
+                .push(Some(16_u16))
+                .push(None::<u32>)
+                .push(Some(64_u64))
+                .push(None::<f32>)
+                .push(Some(6.5_f64))
+                .push(Some("borrowed-str"))
+                .push(Some(String::from("owned-option")))
+                .push(Some(borrowed_bytes))
+                .push(Some(vec![9_u8, 8, 7])),
+        );
+
+        assert!(!batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .expect("$1 should be Boolean")
+            .value(0));
+        assert!(batch.column(1).is_null(0));
+        assert_eq!(
+            batch.column(2)
+                .as_any()
+                .downcast_ref::<Int16Array>()
+                .expect("$3 should be Int16")
+                .value(0),
+            -16
+        );
+        assert!(batch.column(3).is_null(0));
+        assert_eq!(
+            batch.column(4)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("$5 should be Int64")
+                .value(0),
+            -64
+        );
+        assert!(batch.column(5).is_null(0));
+        assert_eq!(
+            batch.column(6)
+                .as_any()
+                .downcast_ref::<UInt16Array>()
+                .expect("$7 should be UInt16")
+                .value(0),
+            16
+        );
+        assert!(batch.column(7).is_null(0));
+        assert_eq!(
+            batch.column(8)
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .expect("$9 should be UInt64")
+                .value(0),
+            64
+        );
+        assert!(batch.column(9).is_null(0));
+        assert_eq!(
+            batch.column(10)
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .expect("$11 should be Float64")
+                .value(0),
+            6.5
+        );
+        assert_eq!(
+            batch.column(11)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("$12 should be Utf8")
+                .value(0),
+            "borrowed-str"
+        );
+        assert_eq!(
+            batch.column(12)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("$13 should be Utf8")
+                .value(0),
+            "owned-option"
+        );
+        assert_eq!(
+            batch.column(13)
+                .as_any()
+                .downcast_ref::<BinaryArray>()
+                .expect("$14 should be Binary")
+                .value(0),
+            borrowed_bytes
+        );
+        assert_eq!(
+            batch.column(14)
+                .as_any()
+                .downcast_ref::<BinaryArray>()
+                .expect("$15 should be Binary")
+                .value(0),
+            &[9_u8, 8, 7]
+        );
+    }
+
+    #[test]
+    fn test_query_parameters_collection_constructors() {
+        assert!(QueryParameters::new().is_empty());
+        assert!(!QueryParameters::new().push(1_i32).is_empty());
+
+        let from_single = batch_from(QueryParameters::from(QueryParameter::from(11_i32)));
+        assert_eq!(
+            from_single
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .expect("single constructor should produce Int32")
+                .value(0),
+            11
+        );
+
+        let from_vec = batch_from(QueryParameters::from(vec![
+            QueryParameter::from(12_i32),
+            QueryParameter::from("vec-constructor"),
+        ]));
+        assert_eq!(
+            from_vec
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .expect("vec constructor should produce Int32")
+                .value(0),
+            12
+        );
+        assert_eq!(
+            from_vec
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("vec constructor should produce Utf8")
+                .value(0),
+            "vec-constructor"
+        );
+
+        let from_array = batch_from(QueryParameters::from([
+            QueryParameter::from(13_i32),
+            QueryParameter::from(14_i64),
+        ]));
+        assert_eq!(
+            from_array
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .expect("array constructor should produce Int32")
+                .value(0),
+            13
+        );
+        assert_eq!(
+            from_array
+                .column(1)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("array constructor should produce Int64")
+                .value(0),
+            14
+        );
+
+        let collected = batch_from(
+            [QueryParameter::from(true), QueryParameter::from(15_u32)]
+                .into_iter()
+                .collect(),
+        );
+        assert!(
+            collected
+                .column(0)
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .expect("collected constructor should produce Boolean")
+                .value(0)
+        );
+        assert_eq!(
+            collected
+                .column(1)
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .expect("collected constructor should produce UInt32")
+                .value(0),
+            15
+        );
+    }
+
+    #[test]
     fn test_query_parameters_empty_batch() {
         let batch = QueryParameters::new()
             .into_record_batch()
@@ -386,14 +1033,19 @@ mod tests {
     }
 
     #[test]
-    fn test_query_parameters_typed_null() {
-        let batch = QueryParameters::new()
-            .push(QueryParameter::null(DataType::Int32))
-            .into_record_batch()
-            .expect("typed null batch should be created")
-            .expect("typed null batch should not be empty");
+    fn test_query_parameters_typed_nulls_preserve_explicit_types() {
+        let batch = batch_from(
+            QueryParameters::new()
+                .push(QueryParameter::null(DataType::Int32))
+                .push(QueryParameter::null(DataType::LargeUtf8))
+                .push(QueryParameter::null(DataType::LargeBinary)),
+        );
 
         assert_eq!(batch.schema().field(0).data_type(), &DataType::Int32);
+        assert_eq!(batch.schema().field(1).data_type(), &DataType::LargeUtf8);
+        assert_eq!(batch.schema().field(2).data_type(), &DataType::LargeBinary);
         assert!(batch.column(0).is_null(0));
+        assert!(batch.column(1).is_null(0));
+        assert!(batch.column(2).is_null(0));
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -33,6 +33,7 @@
 //! }
 //! ```
 
+use crate::dataset::{DatasetError, DatasetRefreshRequest, DatasetRefreshResponse};
 use arrow::array::RecordBatch;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use futures::Stream;
@@ -613,6 +614,73 @@ impl QueryHttpClient {
             status_code => {
                 let response_body = response.text().await.unwrap_or_default();
                 Err(QueryError::HttpRequestFailed {
+                    status_code,
+                    response_body,
+                })
+            }
+        }
+    }
+
+    pub async fn refresh_dataset(
+        &self,
+        dataset_name: &str,
+        request: &DatasetRefreshRequest,
+    ) -> Result<DatasetRefreshResponse, DatasetError> {
+        let mut url = reqwest::Url::parse(&self.base_url).map_err(|e| DatasetError::HttpError {
+            dataset_name: dataset_name.to_string(),
+            message: e.to_string(),
+        })?;
+        {
+            let mut path_segments =
+                url.path_segments_mut()
+                    .map_err(|_| DatasetError::HttpError {
+                        dataset_name: dataset_name.to_string(),
+                        message: "Base URL cannot be used for dataset refresh".to_string(),
+                    })?;
+            path_segments.push("v1");
+            path_segments.push("datasets");
+            path_segments.push(dataset_name);
+            path_segments.push("acceleration");
+            path_segments.push("refresh");
+        }
+
+        let request_builder = self.add_auth(self.client.post(url));
+        let response = if request.has_overrides() {
+            request_builder.json(request).send().await
+        } else {
+            request_builder.send().await
+        }
+        .map_err(|e| DatasetError::HttpError {
+            dataset_name: dataset_name.to_string(),
+            message: e.to_string(),
+        })?;
+
+        match response.status().as_u16() {
+            200 | 201 => response.json().await.map_err(|e| DatasetError::ParseError {
+                dataset_name: dataset_name.to_string(),
+                message: e.to_string(),
+            }),
+            400 => {
+                let response_body = response.text().await.unwrap_or_default();
+                if response_body.contains("does not have acceleration enabled") {
+                    Err(DatasetError::AccelerationNotEnabled {
+                        dataset_name: dataset_name.to_string(),
+                    })
+                } else {
+                    Err(DatasetError::RefreshFailed {
+                        dataset_name: dataset_name.to_string(),
+                        status_code: 400,
+                        response_body,
+                    })
+                }
+            }
+            404 => Err(DatasetError::NotFound {
+                dataset_name: dataset_name.to_string(),
+            }),
+            status_code => {
+                let response_body = response.text().await.unwrap_or_default();
+                Err(DatasetError::RefreshFailed {
+                    dataset_name: dataset_name.to_string(),
                     status_code,
                     response_body,
                 })

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
-    use arrow::array::{ArrayRef, Float64Array, Int32Array};
+    use arrow::array::{ArrayRef, BinaryArray, Float64Array, Int32Array, StringArray};
     use arrow::compute::concat_batches;
     use arrow::datatypes::{
-        DataType::{Float64, Int32},
+        DataType::{Binary, Float64, Int32, Utf8},
         Field, Schema,
     };
     use arrow::record_batch::RecordBatch;
@@ -46,6 +46,20 @@ mod tests {
         let columns = vec![
             Arc::new(Int32Array::from(vec![1])) as ArrayRef,
             Arc::new(Float64Array::from(vec![1.0])) as ArrayRef,
+        ];
+
+        RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
+            .expect("Failed to create RecordBatch")
+    }
+
+    pub fn create_string_binary_param_batch() -> RecordBatch {
+        let fields = vec![
+            Arc::new(Field::new("$1", Utf8, true)),
+            Arc::new(Field::new("$2", Binary, true)),
+        ];
+        let columns = vec![
+            Arc::new(StringArray::from(vec![Some("taxi")])) as ArrayRef,
+            Arc::new(BinaryArray::from(vec![Some(b"cab".as_slice())])) as ArrayRef,
         ];
 
         RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
@@ -261,6 +275,110 @@ mod tests {
                 assert_eq!(batch_concat.num_columns(), 3);
                 assert_eq!(batch_concat.num_rows(), 5);
                 assert_eq!(formatted, get_expected_result());
+            }
+            Err(e) => {
+                panic!("Error: {e}");
+            }
+        };
+    }
+
+    // skip on Windows as we do not provide a spice runtime for Windows
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn test_local_query_with_string_and_binary_bindings() {
+        let _ = rustls::crypto::CryptoProvider::install_default(
+            rustls::crypto::aws_lc_rs::default_provider(),
+        );
+        let spice_client = new_local_client().await;
+        match spice_client
+            .sql_with_bindings(
+                "SELECT $1 AS text_value, $2 AS bytes_value",
+                QueryParameters::new().push("taxi").push(b"cab".as_slice()),
+            )
+            .await
+        {
+            Ok(mut flight_data_stream) => {
+                let mut batches = Vec::new();
+                while let Some(batch) = flight_data_stream.next().await {
+                    match batch {
+                        Ok(batch) => {
+                            batches.push(batch);
+                        }
+                        Err(e) => {
+                            panic!("Error: {e}")
+                        }
+                    }
+                }
+
+                let batch_concat = concat_batches(&batches[0].schema(), &batches)
+                    .expect("Failed to concat batches");
+                assert_eq!(batch_concat.num_columns(), 2);
+                assert_eq!(batch_concat.num_rows(), 1);
+
+                let text_values = batch_concat
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .expect("text_value should be Utf8");
+                assert_eq!(text_values.value(0), "taxi");
+
+                let binary_values = batch_concat
+                    .column(1)
+                    .as_any()
+                    .downcast_ref::<BinaryArray>()
+                    .expect("bytes_value should be Binary");
+                assert_eq!(binary_values.value(0), b"cab");
+            }
+            Err(e) => {
+                panic!("Error: {e}");
+            }
+        };
+    }
+
+    // skip on Windows as we do not provide a spice runtime for Windows
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn test_local_query_with_string_and_binary_params() {
+        let _ = rustls::crypto::CryptoProvider::install_default(
+            rustls::crypto::aws_lc_rs::default_provider(),
+        );
+        let spice_client = new_local_client().await;
+        let params = create_string_binary_param_batch();
+        match spice_client
+            .sql_with_params("SELECT $1 AS text_value, $2 AS bytes_value", Some(params))
+            .await
+        {
+            Ok(mut flight_data_stream) => {
+                let mut batches = Vec::new();
+                while let Some(batch) = flight_data_stream.next().await {
+                    match batch {
+                        Ok(batch) => {
+                            batches.push(batch);
+                        }
+                        Err(e) => {
+                            panic!("Error: {e}")
+                        }
+                    }
+                }
+
+                let batch_concat = concat_batches(&batches[0].schema(), &batches)
+                    .expect("Failed to concat batches");
+                assert_eq!(batch_concat.num_columns(), 2);
+                assert_eq!(batch_concat.num_rows(), 1);
+
+                let text_values = batch_concat
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .expect("text_value should be Utf8");
+                assert_eq!(text_values.value(0), "taxi");
+
+                let binary_values = batch_concat
+                    .column(1)
+                    .as_any()
+                    .downcast_ref::<BinaryArray>()
+                    .expect("bytes_value should be Binary");
+                assert_eq!(binary_values.value(0), b"cab");
             }
             Err(e) => {
                 panic!("Error: {e}");

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -180,6 +180,94 @@ mod tests {
         };
     }
 
+    // skip on Windows as we do not provide a spice runtime for Windows
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn test_local_query_with_params_none() {
+        let _ = rustls::crypto::CryptoProvider::install_default(
+            rustls::crypto::aws_lc_rs::default_provider(),
+        );
+        let spice_client = new_local_client().await;
+        match spice_client
+            .sql_with_params(
+                "SELECT VendorID, tpep_pickup_datetime, fare_amount FROM taxi_trips WHERE VendorID == 1 and fare_amount > 1.0 ORDER BY fare_amount, tpep_pickup_datetime LIMIT 5;",
+                None,
+            )
+            .await
+        {
+            Ok(mut flight_data_stream) => {
+                let mut batches = Vec::new();
+                while let Some(batch) = flight_data_stream.next().await {
+                    match batch {
+                        Ok(batch) => {
+                            batches.push(batch);
+                        }
+                        Err(e) => {
+                            panic!("Error: {e}")
+                        }
+                    }
+                }
+                let batch_concat = concat_batches(&batches[0].schema(), &batches)
+                    .expect("Failed to concat batches");
+                let formatted = format!(
+                    "{}",
+                    pretty_format_batches(&[batch_concat.clone()])
+                        .expect("Failed to format batches")
+                );
+                assert_eq!(batch_concat.num_columns(), 3);
+                assert_eq!(batch_concat.num_rows(), 5);
+                assert_eq!(formatted, get_expected_result());
+            }
+            Err(e) => {
+                panic!("Error: {e}");
+            }
+        };
+    }
+
+    // skip on Windows as we do not provide a spice runtime for Windows
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn test_local_query_with_empty_bindings() {
+        let _ = rustls::crypto::CryptoProvider::install_default(
+            rustls::crypto::aws_lc_rs::default_provider(),
+        );
+        let spice_client = new_local_client().await;
+        match spice_client
+            .sql_with_bindings(
+                "SELECT VendorID, tpep_pickup_datetime, fare_amount FROM taxi_trips WHERE VendorID == 1 and fare_amount > 1.0 ORDER BY fare_amount, tpep_pickup_datetime LIMIT 5;",
+                QueryParameters::new(),
+            )
+            .await
+        {
+            Ok(mut flight_data_stream) => {
+                let mut batches = Vec::new();
+                while let Some(batch) = flight_data_stream.next().await {
+                    match batch {
+                        Ok(batch) => {
+                            batches.push(batch);
+                        }
+                        Err(e) => {
+                            panic!("Error: {e}")
+                        }
+                    }
+                }
+                let batch_concat = concat_batches(&batches[0].schema(), &batches)
+                    .expect("Failed to concat batches");
+                let formatted = format!(
+                    "{}",
+                    pretty_format_batches(&[batch_concat.clone()])
+                        .expect("Failed to format batches")
+                );
+                assert_eq!(batch_concat.num_columns(), 3);
+                assert_eq!(batch_concat.num_rows(), 5);
+                assert_eq!(formatted, get_expected_result());
+            }
+            Err(e) => {
+                panic!("Error: {e}");
+            }
+        };
+    }
+
     #[tokio::test]
     async fn test_query() {
         let spice_client = new_cloud_client().await;

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -9,7 +9,7 @@ mod tests {
     use arrow::record_batch::RecordBatch;
     use arrow::util::pretty::pretty_format_batches;
     use futures::stream::StreamExt;
-    use spiceai::{Client, ClientBuilder};
+    use spiceai::{Client, ClientBuilder, QueryParameters};
     use std::env;
     use std::path::Path;
     use std::sync::Arc;
@@ -126,6 +126,50 @@ mod tests {
                 }
                 let batch_concat = concat_batches(&batches[0].schema(), &batches).expect("Failed to concat batches");
                 let formatted = format!("{}", pretty_format_batches(&[batch_concat.clone()]).expect("Failed to format batches"));
+                assert_eq!(batch_concat.num_columns(), 3);
+                assert_eq!(batch_concat.num_rows(), 5);
+                assert_eq!(formatted, get_expected_result());
+            }
+            Err(e) => {
+                panic!("Error: {e}");
+            }
+        };
+    }
+
+    // skip on Windows as we do not provide a spice runtime for Windows
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn test_local_query_with_bindings() {
+        let _ = rustls::crypto::CryptoProvider::install_default(
+            rustls::crypto::aws_lc_rs::default_provider(),
+        );
+        let spice_client = new_local_client().await;
+        match spice_client
+            .sql_with_bindings(
+                "SELECT VendorID, tpep_pickup_datetime, fare_amount FROM taxi_trips WHERE VendorID == $1 and fare_amount > $2 ORDER BY fare_amount, tpep_pickup_datetime LIMIT 5;",
+                QueryParameters::new().push(1_i32).push(1.0_f64),
+            )
+            .await
+        {
+            Ok(mut flight_data_stream) => {
+                let mut batches = Vec::new();
+                while let Some(batch) = flight_data_stream.next().await {
+                    match batch {
+                        Ok(batch) => {
+                            batches.push(batch);
+                        }
+                        Err(e) => {
+                            panic!("Error: {e}")
+                        }
+                    }
+                }
+                let batch_concat = concat_batches(&batches[0].schema(), &batches)
+                    .expect("Failed to concat batches");
+                let formatted = format!(
+                    "{}",
+                    pretty_format_batches(&[batch_concat.clone()])
+                        .expect("Failed to format batches")
+                );
                 assert_eq!(batch_concat.num_columns(), 3);
                 assert_eq!(batch_concat.num_rows(), 5);
                 assert_eq!(formatted, get_expected_result());


### PR DESCRIPTION
## Summary
- add ergonomic query parameter bindings and dataset refresh support to the Rust SDK
- re-export Arrow from the crate root and update README/examples to match the current API
- switch publishing to GitHub Release-driven automation and update the release checklist accordingly

## Testing
- cargo test --no-run
- cargo clippy --all-features
- cargo test --lib
- cargo test --doc
