### PR TITLE
fix: Configure HTTP/2 keep-alive for faster detection of stale connections

### DIFF
--- a/src/tls.rs
+++ b/src/tls.rs
@@ -3,6 +3,7 @@ use base64::{Engine as _, engine::general_purpose};
 use std::io::Write;
 use std::str::FromStr;
 use std::sync::Once;
+use std::time::Duration;
 
 use tonic::transport::Channel;
 use tonic::transport::channel::{ClientTlsConfig, Endpoint};
@@ -34,6 +35,16 @@ pub async fn new_tls_flight_channel(https_url: &str) -> Result<Channel, GenericE
             .domain_name(https_url.trim_start_matches("https://"));
         endpoint = endpoint.tls_config(tls_config)?;
     }
+
+    // Configure HTTP/2 keep-alive so that stale connections (e.g. after an ALB
+    // target IP change) are detected quickly.  When the keep-alive probe fails,
+    // tonic's built-in Reconnect layer drops the dead connection and establishes
+    // a new one, which triggers a fresh DNS lookup.
+    endpoint = endpoint
+        .keep_alive_while_idle(true)
+        .http2_keep_alive_interval(Duration::from_secs(60))
+        .keep_alive_timeout(Duration::from_secs(20))
+        .tcp_keepalive(Some(Duration::from_secs(60)));
 
     Ok(endpoint.connect().await?)
 }


### PR DESCRIPTION
## Problem

Tonic resolves DNS only when establishing a new connection. Since HTTP/2 connections are long-lived and multiplexed, a client connecting to a load-balanced endpoint (e.g. AWS ALB) can get stuck on a stale IP when backend targets change.

## Fix

Configure HTTP/2 keep-alive settings on the tonic `Endpoint`:

- `http2_keep_alive_interval(60s)` — send HTTP/2 PING frames every 60 seconds
- `keep_alive_timeout(20s)` — drop connection if PING isn't acknowledged within 20 seconds
- `keep_alive_while_idle(true)` — probe even when no active RPCs
- `tcp_keepalive(60s)` — OS-level TCP keepalive as a fallback

When a keep-alive probe fails (because the backend IP is no longer valid), tonic's built-in `Reconnect` layer drops the dead connection and establishes a new one, which triggers a fresh DNS lookup.

## Related

- spiceai/spice-java#39 — equivalent fix for the Java SDK (uses gRPC DnsNameResolver for periodic re-resolution)