### PR TITLE
Port Spice SDK changes to Arrow 58 branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-          - stable
+          - 1.93.1
           - beta
           - nightly
     steps:
@@ -67,7 +67,7 @@ jobs:
             windows-2022,
           ]
         toolchain:
-          - stable
+          - 1.93.1
           - beta
     steps:
       # actions/checkout v4.2.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.93.1
           override: true
 
       - run: cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ bytes = "1.6.0"
 prost = { version = "0.14.1", features = ["derive"] }
 prost-types = "0.14.1"
 rustls = "0.23.5"
-tokio = { version = "1.37.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.37.0", features = ["rt-multi-thread", "fs"] }
 rustls-native-certs = "0.8.1"
 tonic = { version = "0.14", default-features = false, features = [
   "transport",
@@ -22,7 +22,7 @@ tonic = { version = "0.14", default-features = false, features = [
   "tls-native-roots",
 ] }
 rustls-pemfile = "1.0.4"
-reqwest = { version = "0.12.4", features = ["json"] }
+reqwest = { version = "0.12.4", features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.116"
 chrono = { version = "0.4.41", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spiceai"
 version = "3.2.0"
 edition = "2024"
+rust-version = "1.93.1"
 description = "SDK for Spice.ai, an open-source runtime and platform for building AI-driven software."
 license = "Apache-2.0"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.93.1"
+components = ["clippy", "rustfmt"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,7 +4,7 @@ use crate::util::{FibonacciBackoffBuilder, RetryError, retry};
 use crate::{
     config::{GenericError, SPICE_CLOUD_FLIGHT_ADDR, SPICE_LOCAL_FLIGHT_ADDR},
     flight::{SqlFlightClient, is_connection_reset_generic_error},
-    tls::{ensure_crypto_provider, new_tls_flight_channel},
+    tls::{FlightChannelBuilder, ensure_crypto_provider, new_tls_flight_channel},
 };
 use arrow::record_batch::RecordBatch;
 use arrow_flight::error::FlightError;
@@ -408,6 +408,9 @@ pub struct SpiceClientBuilder {
     http_url: Option<String>,
     cache_control: Option<String>,
     max_retries: u32,
+    tls_client_certificate_file: Option<String>,
+    tls_client_key_file: Option<String>,
+    tls_ca_certificate_file: Option<String>,
 }
 
 impl Default for SpiceClientBuilder {
@@ -426,6 +429,9 @@ impl SpiceClientBuilder {
             http_url: None,
             cache_control: None,
             max_retries: MAX_RETRIES,
+            tls_client_certificate_file: None,
+            tls_client_key_file: None,
+            tls_ca_certificate_file: None,
         }
     }
 
@@ -483,6 +489,30 @@ impl SpiceClientBuilder {
         self
     }
 
+    /// Sets the path to a PEM-encoded client certificate file for mTLS.
+    /// Must be used together with [`tls_client_key_file`](Self::tls_client_key_file).
+    #[must_use]
+    pub fn tls_client_certificate_file(mut self, path: &str) -> Self {
+        self.tls_client_certificate_file = Some(path.to_string());
+        self
+    }
+
+    /// Sets the path to a PEM-encoded client private key file for mTLS.
+    /// Must be used together with [`tls_client_certificate_file`](Self::tls_client_certificate_file).
+    #[must_use]
+    pub fn tls_client_key_file(mut self, path: &str) -> Self {
+        self.tls_client_key_file = Some(path.to_string());
+        self
+    }
+
+    /// Sets the path to a custom CA certificate file for server verification.
+    /// When set, this CA is used instead of the system certificate store.
+    #[must_use]
+    pub fn tls_ca_certificate_file(mut self, path: &str) -> Self {
+        self.tls_ca_certificate_file = Some(path.to_string());
+        self
+    }
+
     /// Builds the `SpiceClient` with the specified configuration.
     ///
     /// ## Errors
@@ -490,14 +520,57 @@ impl SpiceClientBuilder {
     /// - `Box<dyn Error + Send + Sync>` if flight channel creation fails
     pub async fn build(self) -> Result<SpiceClient, GenericError> {
         ensure_crypto_provider();
-        let flight_channel = match self.flight_url {
-            Some(url) => new_tls_flight_channel(&url).await?,
-            None => new_tls_flight_channel(SPICE_LOCAL_FLIGHT_ADDR).await?,
-        };
 
-        let http_client = self
-            .http_url
-            .map(|url| Arc::new(QueryHttpClient::new(&url, self.api_key.clone())));
+        // Validate that client cert and key are either both set or both unset
+        match (&self.tls_client_certificate_file, &self.tls_client_key_file) {
+            (Some(_), None) => {
+                return Err("tls_client_certificate_file is set but tls_client_key_file is missing; both must be provided together for mTLS".into());
+            }
+            (None, Some(_)) => {
+                return Err("tls_client_key_file is set but tls_client_certificate_file is missing; both must be provided together for mTLS".into());
+            }
+            _ => {}
+        }
+
+        let url = self
+            .flight_url
+            .as_deref()
+            .unwrap_or(SPICE_LOCAL_FLIGHT_ADDR);
+
+        let mut channel_builder = FlightChannelBuilder::new(url);
+        if let (Some(cert), Some(key)) =
+            (&self.tls_client_certificate_file, &self.tls_client_key_file)
+        {
+            channel_builder = channel_builder.with_client_certificate(cert, key);
+        }
+        if let Some(ca) = &self.tls_ca_certificate_file {
+            channel_builder = channel_builder.with_ca_certificate(ca);
+        }
+        let flight_channel = channel_builder.build().await?;
+
+        let http_client = if let Some(url) = self.http_url {
+            let mut builder = reqwest::Client::builder();
+            if let (Some(cert_path), Some(key_path)) =
+                (&self.tls_client_certificate_file, &self.tls_client_key_file)
+            {
+                let cert_pem = tokio::fs::read(cert_path).await?;
+                let key_pem = tokio::fs::read(key_path).await?;
+                let identity = reqwest::Identity::from_pem(&[cert_pem, key_pem].concat())?;
+                builder = builder.identity(identity);
+            }
+            if let Some(ca_path) = &self.tls_ca_certificate_file {
+                let ca_pem = tokio::fs::read(ca_path).await?;
+                let ca = reqwest::Certificate::from_pem(&ca_pem)?;
+                builder = builder.add_root_certificate(ca);
+            }
+            Some(Arc::new(QueryHttpClient::with_client(
+                builder.build()?,
+                &url,
+                self.api_key.clone(),
+            )))
+        } else {
+            None
+        };
 
         Ok(SpiceClient {
             flight: Arc::new(SqlFlightClient::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod client;
 mod config;
 mod flight;
 pub mod query;
-mod tls;
+pub mod tls;
 mod util;
 
 pub use client::Error as SpiceClientError;

--- a/src/query.rs
+++ b/src/query.rs
@@ -394,8 +394,12 @@ pub(crate) struct QueryHttpClient {
 
 impl QueryHttpClient {
     pub fn new(base_url: &str, api_key: Option<String>) -> Self {
+        Self::with_client(reqwest::Client::new(), base_url, api_key)
+    }
+
+    pub fn with_client(client: reqwest::Client, base_url: &str, api_key: Option<String>) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client,
             base_url: base_url.trim_end_matches('/').to_string(),
             api_key,
         }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,16 +1,17 @@
 use crate::config::GenericError;
 use base64::{Engine as _, engine::general_purpose};
 use std::io::Write;
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Once;
 
-use tonic::transport::Channel;
 use tonic::transport::channel::{ClientTlsConfig, Endpoint};
+use tonic::transport::{Channel, Identity};
 
 static INIT: Once = Once::new();
 
 pub fn system_tls_certificate() -> Result<tonic::transport::Certificate, GenericError> {
-    // Load root certificates found in the platform’s native certificate store.
+    // Load root certificates found in the platform's native certificate store.
     // Use the same pem format as spiceai cloud connector: https://github.com/spiceai/spiceai/blob/571007c4be89a2a9892e3bd0eb43f8bd28464a69/crates/flight_client/src/tls.rs#L47
     let cert_result = rustls_native_certs::load_native_certs();
 
@@ -24,18 +25,112 @@ pub fn system_tls_certificate() -> Result<tonic::transport::Certificate, Generic
     Ok(tonic::transport::Certificate::from_pem(pem))
 }
 
-pub async fn new_tls_flight_channel(https_url: &str) -> Result<Channel, GenericError> {
-    let mut endpoint = Endpoint::from_str(https_url)?;
+/// Builder for creating TLS-enabled Flight channels.
+///
+/// # Examples
+///
+/// ```no_run
+/// # async fn example() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// use spiceai::tls::FlightChannelBuilder;
+///
+/// // Basic TLS (system roots)
+/// let channel = FlightChannelBuilder::new("https://flight.spiceai.io")
+///     .build()
+///     .await?;
+///
+/// // With mTLS client certificate
+/// let channel = FlightChannelBuilder::new("https://localhost:50051")
+///     .with_client_certificate("client.crt", "client.key")
+///     .build()
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct FlightChannelBuilder {
+    url: String,
+    client_cert_path: Option<PathBuf>,
+    client_key_path: Option<PathBuf>,
+    ca_cert_path: Option<PathBuf>,
+}
 
-    if https_url.starts_with("https://") {
-        let cert = system_tls_certificate()?;
-        let tls_config = ClientTlsConfig::new()
-            .ca_certificate(cert)
-            .domain_name(https_url.trim_start_matches("https://"));
-        endpoint = endpoint.tls_config(tls_config)?;
+impl FlightChannelBuilder {
+    /// Creates a new builder for the given endpoint URL.
+    #[must_use]
+    pub fn new(url: &str) -> Self {
+        Self {
+            url: url.to_string(),
+            client_cert_path: None,
+            client_key_path: None,
+            ca_cert_path: None,
+        }
     }
 
-    Ok(endpoint.connect().await?)
+    /// Sets a custom CA certificate file for server verification.
+    ///
+    /// When set, this CA is used instead of the system certificate store.
+    #[must_use]
+    pub fn with_ca_certificate(mut self, ca_path: impl Into<PathBuf>) -> Self {
+        self.ca_cert_path = Some(ca_path.into());
+        self
+    }
+
+    /// Sets the client certificate and key files for mutual TLS.
+    ///
+    /// Both files must be PEM-encoded. The certificate is presented to
+    /// the server during the TLS handshake.
+    #[must_use]
+    pub fn with_client_certificate(
+        mut self,
+        cert_path: impl Into<PathBuf>,
+        key_path: impl Into<PathBuf>,
+    ) -> Self {
+        self.client_cert_path = Some(cert_path.into());
+        self.client_key_path = Some(key_path.into());
+        self
+    }
+
+    /// Builds and connects the Flight channel.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the TLS configuration is invalid, the
+    /// certificate files cannot be read, or the connection fails.
+    pub async fn build(self) -> Result<Channel, GenericError> {
+        let mut endpoint = Endpoint::from_str(&self.url)?;
+
+        if self.url.starts_with("https://") {
+            let cert = if let Some(ca_path) = &self.ca_cert_path {
+                let ca_pem = tokio::fs::read(ca_path).await?;
+                tonic::transport::Certificate::from_pem(ca_pem)
+            } else {
+                system_tls_certificate()?
+            };
+            let domain = self.url.trim_start_matches("https://");
+            let domain = domain.split(':').next().unwrap_or(domain);
+            let mut tls_config = ClientTlsConfig::new()
+                .ca_certificate(cert)
+                .domain_name(domain);
+
+            if let (Some(cert_path), Some(key_path)) =
+                (&self.client_cert_path, &self.client_key_path)
+            {
+                let cert_pem = tokio::fs::read(cert_path).await?;
+                let key_pem = tokio::fs::read(key_path).await?;
+                tls_config = tls_config.identity(Identity::from_pem(cert_pem, key_pem));
+            }
+
+            endpoint = endpoint.tls_config(tls_config)?;
+        }
+
+        Ok(endpoint.connect().await?)
+    }
+}
+
+/// Creates a new TLS-enabled Flight channel.
+///
+/// Equivalent to `FlightChannelBuilder::new(url).build()`.
+pub async fn new_tls_flight_channel(url: &str) -> Result<Channel, GenericError> {
+    FlightChannelBuilder::new(url).build().await
 }
 
 pub(crate) fn ensure_crypto_provider() {
@@ -85,85 +180,60 @@ mod tests {
 
     #[test]
     fn test_endpoint_parsing_valid_https() {
-        use std::str::FromStr;
-        use tonic::transport::channel::Endpoint;
-
         let endpoint = Endpoint::from_str("https://flight.spiceai.io");
         assert!(endpoint.is_ok());
     }
 
     #[test]
     fn test_endpoint_parsing_valid_http() {
-        use std::str::FromStr;
-        use tonic::transport::channel::Endpoint;
-
         let endpoint = Endpoint::from_str("http://localhost:50051");
         assert!(endpoint.is_ok());
     }
 
-    // Edge case tests
-
     #[tokio::test]
     async fn test_new_tls_flight_channel_empty_url() {
-        // Empty URL should fail
         let result = new_tls_flight_channel("").await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn test_new_tls_flight_channel_unreachable_port() {
-        // Connection to an unreachable port should fail
         let result = new_tls_flight_channel("http://127.0.0.1:1").await;
-        // Port 1 is typically not open, so connection should fail
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn test_new_tls_flight_channel_missing_scheme() {
-        // Missing scheme should fail
         let result = new_tls_flight_channel("example.com:443").await;
         assert!(result.is_err());
     }
 
     #[test]
     fn test_endpoint_parsing_with_path() {
-        use std::str::FromStr;
-        use tonic::transport::channel::Endpoint;
-
         let endpoint = Endpoint::from_str("https://flight.spiceai.io/path");
         assert!(endpoint.is_ok());
     }
 
     #[test]
     fn test_endpoint_parsing_with_port() {
-        use std::str::FromStr;
-        use tonic::transport::channel::Endpoint;
-
         let endpoint = Endpoint::from_str("https://flight.spiceai.io:443");
         assert!(endpoint.is_ok());
     }
 
     #[test]
     fn test_endpoint_parsing_localhost_ipv4() {
-        use std::str::FromStr;
-        use tonic::transport::channel::Endpoint;
-
         let endpoint = Endpoint::from_str("http://127.0.0.1:50051");
         assert!(endpoint.is_ok());
     }
 
     #[test]
     fn test_endpoint_parsing_localhost_ipv6() {
-        use std::str::FromStr;
-        use tonic::transport::channel::Endpoint;
-
         let endpoint = Endpoint::from_str("http://[::1]:50051");
         assert!(endpoint.is_ok());
     }
 
     #[test]
     fn test_system_tls_certificate_pem_format() {
-        // Verify the certificate loads and is in valid PEM format
         let result = system_tls_certificate();
         assert!(
             result.is_ok(),
@@ -174,7 +244,28 @@ mod tests {
     #[test]
     fn test_crypto_provider_is_installed_after_ensure() {
         ensure_crypto_provider();
-        // After ensuring, provider should be installed
         assert!(rustls::crypto::CryptoProvider::get_default().is_some());
+    }
+
+    #[test]
+    fn test_flight_channel_builder_new() {
+        let builder = FlightChannelBuilder::new("https://localhost:50051");
+        assert_eq!(builder.url, "https://localhost:50051");
+        assert!(builder.client_cert_path.is_none());
+        assert!(builder.client_key_path.is_none());
+    }
+
+    #[test]
+    fn test_flight_channel_builder_with_client_certificate() {
+        let builder = FlightChannelBuilder::new("https://localhost:50051")
+            .with_client_certificate("client.crt", "client.key");
+        assert_eq!(
+            builder.client_cert_path.as_deref(),
+            Some(std::path::Path::new("client.crt"))
+        );
+        assert_eq!(
+            builder.client_key_path.as_deref(),
+            Some(std::path::Path::new("client.key"))
+        );
     }
 }


### PR DESCRIPTION
Ports the current Spice SDK trunk changes onto the Arrow 58 feature branch.

Base: `spiceai-58`
Head: `spiceai-58-patches`

This follows the DataFusion upgrade guide branch shape: patch PRs target the version branch, not the repository default branch.