### PR TITLE
ci: move ubuntu-22.04 jobs to ubuntu-24.04 (Spice CLI GLIBC 2.38+ floor)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
         os:
           [
             ubuntu-latest,
-            ubuntu-22.04,
+            ubuntu-24.04,
             macos-latest,
             macos-14,
             windows-latest,
@@ -141,7 +141,11 @@ jobs:
 
       - name: Stop spice and check logs
         working-directory: spice_qs
-        if: "!startsWith(matrix.os, 'windows') && always()"
+        # Guard on spice_qs existing: a failed `spice install`/`spice init`
+        # never creates the working-directory, which would otherwise make this
+        # always() step error with "No such file or directory" and mask the
+        # real failure.
+        if: "always() && !startsWith(matrix.os, 'windows') && hashFiles('spice_qs/**') != ''"
         run: |
           killall spice || true
           cat spice.log


### PR DESCRIPTION
## Problem

The `ubuntu-22.04` matrix leg of `build_and_test` (`.github/workflows/build.yml`) is red trunk-wide.

**Root cause — GLIBC floor.** The prebuilt Spice CLI served from `https://install.spiceai.org` now links against GLIBC 2.38/2.39, but `ubuntu-22.04` GitHub runners ship GLIBC 2.35. The `spice install` step therefore fails with:

```
version `GLIBC_2.38' not found
```

**Cascading failure.** Once `spice install`/`spice init` fails, the `spice_qs` project directory is never created. The `if: always()` "Stop spice and check logs" step uses `working-directory: spice_qs`, so it then errors out with:

```
No such file or directory
```

masking the real (GLIBC) cause and producing a confusing second red step.

## Changes

1. **Move the matrix entry `ubuntu-22.04` → `ubuntu-24.04`.** `ubuntu-24.04` ships GLIBC 2.39, which satisfies the CLI's new floor. (`ubuntu-latest` is left untouched as a separate intentional matrix entry.)
2. **Harden the "Stop spice and check logs" step** so a failed install/init no longer cascades. The `if` guard now also requires `hashFiles('spice_qs/**') != ''`, so the step is cleanly skipped (instead of erroring) when the `spice_qs` working-directory was never created. This keeps the real failure visible.

```yaml
if: "always() && !startsWith(matrix.os, 'windows') && hashFiles('spice_qs/**') != ''"
```

## Impact

Workflow-only change — no code or dependency changes. This unblocks the red `build_and_test` jobs on trunk and on the open PR #70.

## Check expectations

- New `Build and test ubuntu-24.04 on <toolchain>` matrix legs run (replacing the failing `ubuntu-22.04` legs); `spice install` succeeds against GLIBC 2.39.
- The `ubuntu-22.04` legs disappear from the check list.
- If a future install/init ever fails, the "Stop spice and check logs" step is skipped rather than producing a misleading "No such file or directory" error, so the originating failure stays surfaced.
- All other matrix legs (`ubuntu-latest`, `macos-latest`, `macos-14`, `windows-latest`, `windows-2022`) are unchanged.
