### PR TITLE
Upgrade to Arrow 58 / arrow-flight 58 (+ tonic 0.14)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
         os:
           [
             ubuntu-latest,
-            ubuntu-22.04,
+            ubuntu-24.04,
             macos-latest,
             macos-14,
             windows-latest,
@@ -141,7 +141,11 @@ jobs:
 
       - name: Stop spice and check logs
         working-directory: spice_qs
-        if: "!startsWith(matrix.os, 'windows') && always()"
+        # Guard on spice_qs existing: a failed `spice install`/`spice init`
+        # never creates the working-directory, which would otherwise make this
+        # always() step error with "No such file or directory" and mask the
+        # real failure.
+        if: "always() && !startsWith(matrix.os, 'windows') && hashFiles('spice_qs/**') != ''"
         run: |
           killall spice || true
           cat spice.log

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ description = "SDK for Spice.ai, an open-source runtime and platform for buildin
 license = "Apache-2.0"
 
 [dependencies]
-arrow = { version = "57.2", features = ["prettyprint"] }
-arrow-flight = { version = "57.2", features = ["flight-sql-experimental"] }
-arrow-json = "57.2"
+arrow = { version = "58", features = ["prettyprint"] }
+arrow-flight = { version = "58", features = ["flight-sql-experimental"] }
+arrow-json = "58"
 bytes = "1.6.0"
 prost = { version = "0.14.1", features = ["derive"] }
 prost-types = "0.14.1"


### PR DESCRIPTION
## Summary

Upgrades the Arrow dependencies from **57.2 → 58** (crates.io, resolves to `58.3.0`):

```diff
- arrow        = { version = "57.2", features = ["prettyprint"] }
- arrow-flight = { version = "57.2", features = ["flight-sql-experimental"] }
- arrow-json   = "57.2"
+ arrow        = { version = "58", features = ["prettyprint"] }
+ arrow-flight = { version = "58", features = ["flight-sql-experimental"] }
+ arrow-json   = "58"
```

This is the only source change — `Cargo.lock` is git-ignored for this library crate, so the bump is a single edit to `Cargo.toml`.

## Arrow 57 → 58 API adaptations

**None were required.** This SDK only touches stable, high-level Arrow surfaces that did not change across 57 → 58:

- `arrow::record_batch::RecordBatch`, `arrow::datatypes::{Schema, Field, DataType, TimeUnit, IntervalUnit}`
- `arrow_json::ReaderBuilder` (async-query JSON → RecordBatch path in `query.rs`)
- `arrow::compute::concat_batches`, `arrow::util::pretty::pretty_format_batches`, `arrow::array::{Int32Array, Float64Array, ArrayRef}` (tests)
- `arrow_flight` client types: `FlightServiceClient`, `FlightSqlServiceClient`, `FlightRecordBatchStream`, `FlightDescriptor`, `HandshakeRequest`, `FlightError`

There is no direct array down-casting in the crate, so the common 57→58 churn (the `AsArray` trait + turbofish for `as_list`/`as_string`/`as_primitive`, IPC/`StreamWriter` shifts) does not apply here.

## tonic / prost

The brief anticipated a tonic 0.14 / prost 0.14 ripple from arrow-flight 58. In practice **trunk already migrated to tonic 0.14 + prost 0.14** (#65 / #66), and `arrow-flight 58.3.0` requires exactly `tonic ^0.14.1`, `tonic-prost ^0.14.1`, `prost ^0.14.1`, `prost-types ^0.14.1` — all already satisfied. So **no tonic/prost/codegen changes were needed** in this PR; the Flight client code (`flight.rs`, `tls.rs`) compiles unchanged. The lockfile keeps `tonic 0.14.2` / `tonic-prost 0.14.2` / `prost 0.14.3`.

(Side effect of the resolve: arrow 58's lighter tree drops a few transitive dev-deps — `wiremock`, `deadpool`, `assert-json-diff`, `num_cpus` — and bumps `hashbrown 0.16 → 0.17`. No code impact.)

## Test results (local, `--all-features`)

- `cargo check --all-targets --all-features` — clean (exit 0)
- `cargo test --lib --all-features` — **162 passed, 0 failed, 0 ignored**
- `cargo clippy --all-features` (the CI gate) — passes (exit 0)

Note: clippy emits one **pre-existing** `dead_code` warning for `QueryHttpClient::new` (`src/query.rs`), introduced by the mTLS PR (#72) when the production call site moved to `QueryHttpClient::with_client` — `new()` is now used only in `#[cfg(test)]`. It is unrelated to this Arrow bump and does not fail CI (the workflow runs `cargo clippy` without `-D warnings`). Left as-is to keep this PR surgical; it's a one-liner to fix separately (e.g. `#[cfg(test)]` or `#[allow(dead_code)]`).

The `tests/client_test.rs` integration tests are not part of the lib-test count — they require a running spiced + `SCP_SPICEAI_TPCH_API_KEY`, so they run only in CI's `build_and_test` job.

## Merge-order note (re: #70)

PR #70 (`lukim/issues`, query bindings / dataset refresh / release flow) also edits `Cargo.toml` (and `src/query.rs`, `src/client.rs`, `src/tls.rs`). This PR's only file overlap is the `Cargo.toml` `[dependencies]` arrow lines. **Whichever of #70 / this PR merges second should keep the `arrow*` lines at `"58"`** — the conflict is a trivial 3-line version-string resolution. No logic overlaps.

## Follow-up in spice2 (after this merges)

spice2's DF53/Arrow58 work currently bridges the SDK with arrow-57↔58 shims. Once this lands:

1. **Re-pin the SDK** in spice2's root `Cargo.toml` (`[workspace.dependencies] spiceai`) to this PR's merge commit on `trunk` (currently pinned to an older trunk rev). The SDK is consumed by `crates/test-framework` and `bin/spice` (the `spice` CLI) via `spiceai = { workspace = true }`.
2. **Remove the arrow-58 bridge shims** at the SDK call sites once both sides agree on the arrow-58 ABI:
   - `crates/test-framework/src/flight/mod.rs`, `.../spiced/mod.rs`, `.../snapshot/mod.rs`, `.../execution/mod.rs`
   - `bin/spice/src/commands/query/mod.rs`, `bin/spice/src/commands/nsql/analyze.rs`

   (spice2 uses the **spiceai arrow fork**, while this SDK uses **crates.io arrow 58** — whether any conversion remains after the re-pin depends on crates-58 vs fork-58 ABI identity, which is spice2's call.)
