### PR TITLE
feat(query): parameterized async /v1/queries submit + options

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 }
 ```
 
+Async queries also accept positional bindings (`$1`, `$2`, ...) and submit options. Use `query_with_bindings` for the common parameterized case, or `query_with_options` to also set an execution `timeout_seconds` or a `maximum_size` cap on the materialized result.
+
+```rust,no_run
+use spiceai::{ClientBuilder, QueryParameters, QuerySubmitOptions};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+  let client = ClientBuilder::new()
+    .http_url("http://localhost:8090")
+    .build()
+    .await?;
+
+  let job = client
+    .query_with_options(
+      "SELECT * FROM large_table WHERE status = $1 AND created_at > $2",
+      QuerySubmitOptions::new()
+        .bindings(QueryParameters::new().push("active").push("2025-01-01"))
+        .timeout_seconds(300)
+        .maximum_size(100_000_000),
+    )
+    .await?;
+
+  let result = job.wait().await?;
+  println!("completed with {} rows", result.total_rows);
+  Ok(())
+}
+```
+
 ## Documentation
 
 Check out our [Documentation](https://docs.spice.ai/sdks/rust-sdk) to learn more about how to use the Rust SDK.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
 use crate::flight::RetryableQueryStream;
 use crate::params::{QueryParameterError, QueryParameters};
-use crate::query::{QueryError, QueryHttpClient, QueryJob};
+use crate::query::{QueryError, QueryHttpClient, QueryJob, QuerySubmitOptions};
 use crate::util::{FibonacciBackoffBuilder, RetryError, retry};
 use crate::{
     config::{GenericError, SPICE_CLOUD_FLIGHT_ADDR, SPICE_LOCAL_FLIGHT_ADDR},
@@ -274,7 +274,125 @@ impl SpiceClient {
                 .to_string(),
         })?;
 
-        let response = http_client.submit(sql).await?;
+        let response = http_client.submit(sql, None, None, None).await?;
+        Ok(QueryJob::new(response.query_id, Arc::clone(http_client)))
+    }
+
+    /// Submits an async parameterized SQL query using scalar bindings.
+    ///
+    /// This is the async (`/v1/queries`) counterpart to
+    /// [`sql_with_bindings()`](Self::sql_with_bindings): it binds a single row of
+    /// positional scalar values (`$1`, `$2`, ...) and returns a [`QueryJob`]
+    /// handle. To also set a timeout or result-size cap, use
+    /// [`query_with_options()`](Self::query_with_options).
+    ///
+    /// **Note:** Requires [`http_url()`](SpiceClientBuilder::http_url) to be configured.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use spiceai::{ClientBuilder, QueryParameters};
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// let client = ClientBuilder::new()
+    ///     .http_url("http://localhost:8090")
+    ///     .build()
+    ///     .await?;
+    ///
+    /// let job = client
+    ///     .query_with_bindings(
+    ///         "SELECT * FROM large_table WHERE status = $1",
+    ///         QueryParameters::new().push("active"),
+    ///     )
+    ///     .await?;
+    /// println!("Query submitted: {}", job.id());
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// - [`QueryError::InvalidParameter`] if a binding cannot be encoded as JSON
+    /// - [`QueryError::ClusterModeRequired`] if async queries are not enabled
+    /// - [`QueryError::SubmitFailed`] if the query submission fails
+    /// - [`QueryError::HttpError`] if the HTTP endpoint is not configured or unreachable
+    pub async fn query_with_bindings(
+        &self,
+        sql: &str,
+        params: QueryParameters,
+    ) -> Result<QueryJob, QueryError> {
+        self.query_with_options(sql, QuerySubmitOptions::new().bindings(params))
+            .await
+    }
+
+    /// Submits an async SQL query with explicit submit options.
+    ///
+    /// [`QuerySubmitOptions`] carries the optional bind parameters, a server-side
+    /// execution `timeout_seconds`, and a `maximum_size` cap on the materialized
+    /// result. Any option left unset is omitted from the request so the server
+    /// applies its default.
+    ///
+    /// **Note:** Requires [`http_url()`](SpiceClientBuilder::http_url) to be configured.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use spiceai::{ClientBuilder, QueryParameters, QuerySubmitOptions};
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// let client = ClientBuilder::new()
+    ///     .http_url("http://localhost:8090")
+    ///     .build()
+    ///     .await?;
+    ///
+    /// let job = client
+    ///     .query_with_options(
+    ///         "SELECT * FROM large_table WHERE status = $1",
+    ///         QuerySubmitOptions::new()
+    ///             .bindings(QueryParameters::new().push("active"))
+    ///             .timeout_seconds(300)
+    ///             .maximum_size(100_000_000),
+    ///     )
+    ///     .await?;
+    /// let result = job.wait().await?;
+    /// println!("Completed with {} rows", result.total_rows);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// - [`QueryError::InvalidParameter`] if a binding cannot be encoded as JSON
+    /// - [`QueryError::ClusterModeRequired`] if async queries are not enabled
+    /// - [`QueryError::SubmitFailed`] if the query submission fails
+    /// - [`QueryError::HttpError`] if the HTTP endpoint is not configured or unreachable
+    pub async fn query_with_options(
+        &self,
+        sql: &str,
+        options: QuerySubmitOptions,
+    ) -> Result<QueryJob, QueryError> {
+        let http_client = self.http_client.as_ref().ok_or(QueryError::HttpError {
+            message: "HTTP endpoint not configured. Use ClientBuilder::http_url() to set it."
+                .to_string(),
+        })?;
+
+        let parameters = match &options.bindings {
+            Some(params) if !params.is_empty() => Some(
+                params
+                    .to_json_values()
+                    .map_err(|source| QueryError::InvalidParameter { source })?,
+            ),
+            _ => None,
+        };
+
+        let response = http_client
+            .submit(
+                sql,
+                parameters,
+                options.timeout_seconds,
+                options.maximum_size,
+            )
+            .await?;
         Ok(QueryJob::new(response.query_id, Arc::clone(http_client)))
     }
 
@@ -982,6 +1100,83 @@ mod tests {
                 .await,
             Err(DatasetError::HttpError { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn test_query_with_bindings_submits_parameters() {
+        let server = MockServer::start().await;
+        let query_id = "qry_params";
+        let sql = "SELECT * FROM t WHERE status = $1 AND n > $2";
+
+        Mock::given(method("POST"))
+            .and(path("/v1/queries"))
+            .and(body_json(
+                json!({ "sql": sql, "parameters": ["active", 5] }),
+            ))
+            .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+                "query_id": query_id,
+                "status": "PENDING",
+                "status_url": format!("{}/v1/queries/{query_id}/status", server.uri()),
+                "results_url": format!("{}/v1/queries/{query_id}/results", server.uri())
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(Some(&server.uri()));
+        let job = client
+            .query_with_bindings(sql, QueryParameters::new().push("active").push(5_i64))
+            .await
+            .expect("submit parameterized async query");
+        assert_eq!(job.id(), query_id);
+    }
+
+    #[tokio::test]
+    async fn test_query_with_options_submits_all_fields() {
+        let server = MockServer::start().await;
+        let query_id = "qry_opts";
+        let sql = "SELECT * FROM t WHERE status = $1";
+
+        Mock::given(method("POST"))
+            .and(path("/v1/queries"))
+            .and(body_json(json!({
+                "sql": sql,
+                "parameters": ["active"],
+                "timeout_seconds": 300,
+                "maximum_size": 100_000_000
+            })))
+            .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+                "query_id": query_id,
+                "status": "PENDING",
+                "status_url": format!("{}/v1/queries/{query_id}/status", server.uri()),
+                "results_url": format!("{}/v1/queries/{query_id}/results", server.uri())
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(Some(&server.uri()));
+        let job = client
+            .query_with_options(
+                sql,
+                QuerySubmitOptions::new()
+                    .bindings(QueryParameters::new().push("active"))
+                    .timeout_seconds(300)
+                    .maximum_size(100_000_000),
+            )
+            .await
+            .expect("submit async query with options");
+        assert_eq!(job.id(), query_id);
+    }
+
+    #[tokio::test]
+    async fn test_query_with_bindings_rejects_unsupported_param() {
+        // A binary bind value has no JSON scalar form; the client must reject it
+        // locally, before any HTTP request is attempted.
+        let client = test_client(Some("http://127.0.0.1:1"));
+        let err = client
+            .query_with_bindings("SELECT $1", QueryParameters::new().push(vec![1_u8, 2, 3]))
+            .await
+            .expect_err("binary bind parameter should be rejected before submit");
+        assert!(matches!(err, QueryError::InvalidParameter { .. }));
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub use dataset::{
 pub use params::{QueryParameter, QueryParameterError, QueryParameters};
 pub use query::{
     QueryError, QueryInfo, QueryJob, QueryListResponse, QueryResult, QueryResultStream,
-    QueryStatus, QuerySummary,
+    QueryStatus, QuerySubmitOptions, QuerySummary,
 };
 
 // Further public exports and integrations

--- a/src/params.rs
+++ b/src/params.rs
@@ -18,6 +18,9 @@ pub enum QueryParameterError {
         "Query parameter arrays must contain exactly one value, got {array_length}"
     ))]
     InvalidArrayLength { array_length: usize },
+
+    #[snafu(display("{message}"))]
+    UnsupportedJsonParameter { message: String },
 }
 
 #[derive(Debug, Clone, Default)]
@@ -59,6 +62,28 @@ impl QueryParameters {
         RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
             .map(Some)
             .map_err(|source| QueryParameterError::BatchCreation { source })
+    }
+
+    /// Encodes these parameters as the JSON array expected by the async
+    /// `/v1/queries` API, i.e. positional bind values (`$1`, `$2`, ...).
+    ///
+    /// Unlike [`into_record_batch()`](Self::into_record_batch), which produces an
+    /// Arrow batch for the Flight path, the HTTP async API accepts scalar bind
+    /// values as a JSON array. Non-scalar parameters
+    /// ([`QueryParameter::Array`]) and binary parameters have no JSON scalar
+    /// representation and return [`QueryParameterError::UnsupportedJsonParameter`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QueryParameterError::UnsupportedJsonParameter`] if any parameter
+    /// cannot be represented as a JSON scalar (binary, array, or non-finite float).
+    pub fn to_json_values(&self) -> Result<serde_json::Value, QueryParameterError> {
+        let values = self
+            .values
+            .iter()
+            .map(QueryParameter::to_json_value)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(serde_json::Value::Array(values))
     }
 }
 
@@ -115,6 +140,64 @@ impl QueryParameter {
     #[must_use]
     pub fn null(data_type: DataType) -> Self {
         Self::Null(data_type)
+    }
+
+    /// Converts this scalar parameter into a JSON value for the async
+    /// `/v1/queries` API. A `NULL` parameter maps to JSON `null`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QueryParameterError::UnsupportedJsonParameter`] for parameters
+    /// with no JSON scalar representation: binary ([`QueryParameter::Binary`],
+    /// [`QueryParameter::LargeBinary`]), arrays ([`QueryParameter::Array`]), and
+    /// non-finite floats (`NaN`/`Inf`).
+    pub fn to_json_value(&self) -> Result<serde_json::Value, QueryParameterError> {
+        use serde_json::Value;
+
+        let value = match self {
+            Self::Boolean(v) => (*v).map_or(Value::Null, Value::Bool),
+            Self::Int8(v) => (*v).map_or(Value::Null, Value::from),
+            Self::Int16(v) => (*v).map_or(Value::Null, Value::from),
+            Self::Int32(v) => (*v).map_or(Value::Null, Value::from),
+            Self::Int64(v) => (*v).map_or(Value::Null, Value::from),
+            Self::UInt8(v) => (*v).map_or(Value::Null, Value::from),
+            Self::UInt16(v) => (*v).map_or(Value::Null, Value::from),
+            Self::UInt32(v) => (*v).map_or(Value::Null, Value::from),
+            Self::UInt64(v) => (*v).map_or(Value::Null, Value::from),
+            Self::Float32(v) => match v {
+                Some(f) => Self::finite_json_number(f64::from(*f))?,
+                None => Value::Null,
+            },
+            Self::Float64(v) => match v {
+                Some(f) => Self::finite_json_number(*f)?,
+                None => Value::Null,
+            },
+            Self::Utf8(v) | Self::LargeUtf8(v) => v.clone().map_or(Value::Null, Value::String),
+            Self::Null(_) => Value::Null,
+            Self::Binary(_) | Self::LargeBinary(_) => {
+                return Err(QueryParameterError::UnsupportedJsonParameter {
+                    message: "binary parameters are not supported by the async /v1/queries API"
+                        .to_string(),
+                });
+            }
+            Self::Array(_) => {
+                return Err(QueryParameterError::UnsupportedJsonParameter {
+                    message: "array parameters are not supported by the async /v1/queries API; \
+                              use scalar bind values"
+                        .to_string(),
+                });
+            }
+        };
+
+        Ok(value)
+    }
+
+    fn finite_json_number(value: f64) -> Result<serde_json::Value, QueryParameterError> {
+        serde_json::Number::from_f64(value)
+            .map(serde_json::Value::Number)
+            .ok_or_else(|| QueryParameterError::UnsupportedJsonParameter {
+                message: format!("non-finite float parameter ({value}) cannot be encoded as JSON"),
+            })
     }
 
     pub fn array<A>(array: A) -> Result<Self, QueryParameterError>
@@ -396,6 +479,66 @@ mod tests {
     };
     use arrow::datatypes::{IntervalUnit, TimeUnit, UnionFields, UnionMode};
     use std::sync::Arc;
+
+    #[test]
+    fn to_json_values_encodes_scalars() {
+        let params = QueryParameters::new()
+            .push("active")
+            .push(5_i64)
+            .push(1.5_f64)
+            .push(true);
+        assert_eq!(
+            params.to_json_values().expect("scalars encode"),
+            serde_json::json!(["active", 5, 1.5, true])
+        );
+    }
+
+    #[test]
+    fn to_json_values_encodes_null_binding() {
+        let params = QueryParameters::new().push(None::<i32>);
+        assert_eq!(
+            params.to_json_values().expect("null encodes"),
+            serde_json::json!([null])
+        );
+    }
+
+    #[test]
+    fn to_json_values_empty_is_empty_array() {
+        assert_eq!(
+            QueryParameters::new()
+                .to_json_values()
+                .expect("empty encodes"),
+            serde_json::json!([])
+        );
+    }
+
+    #[test]
+    fn to_json_values_rejects_binary() {
+        let params = QueryParameters::new().push(vec![1_u8, 2, 3]);
+        assert!(matches!(
+            params.to_json_values(),
+            Err(QueryParameterError::UnsupportedJsonParameter { .. })
+        ));
+    }
+
+    #[test]
+    fn to_json_values_rejects_array() {
+        let array =
+            QueryParameter::array(Int32Array::from(vec![1])).expect("single-element array param");
+        assert!(matches!(
+            QueryParameters::from(array).to_json_values(),
+            Err(QueryParameterError::UnsupportedJsonParameter { .. })
+        ));
+    }
+
+    #[test]
+    fn to_json_values_rejects_non_finite_float() {
+        let params = QueryParameters::new().push(f64::NAN);
+        assert!(matches!(
+            params.to_json_values(),
+            Err(QueryParameterError::UnsupportedJsonParameter { .. })
+        ));
+    }
 
     fn batch_from(params: QueryParameters) -> RecordBatch {
         params

--- a/src/query.rs
+++ b/src/query.rs
@@ -34,6 +34,7 @@
 //! ```
 
 use crate::dataset::{DatasetError, DatasetRefreshRequest, DatasetRefreshResponse};
+use crate::params::{QueryParameterError, QueryParameters};
 use arrow::array::RecordBatch;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use futures::Stream;
@@ -109,6 +110,65 @@ pub enum QueryError {
     /// Failed to deserialize Arrow data from server response.
     #[snafu(display("Failed to deserialize Arrow data: {message}"))]
     ArrowError { message: String },
+
+    /// A bind parameter could not be encoded for the async `/v1/queries` API.
+    #[snafu(display("Invalid query parameter: {source}"))]
+    InvalidParameter {
+        /// The underlying parameter conversion error.
+        source: QueryParameterError,
+    },
+}
+
+/// Options for submitting an async query via
+/// [`SpiceClient::query_with_options`](crate::Client::query_with_options).
+///
+/// Construct with [`QuerySubmitOptions::new`] and chain the builder methods.
+/// Unset fields are omitted from the request, letting the server apply its
+/// defaults.
+///
+/// ```
+/// use spiceai::{QueryParameters, QuerySubmitOptions};
+///
+/// let options = QuerySubmitOptions::new()
+///     .bindings(QueryParameters::new().push("active"))
+///     .timeout_seconds(300)
+///     .maximum_size(100_000_000);
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct QuerySubmitOptions {
+    pub(crate) bindings: Option<QueryParameters>,
+    pub(crate) timeout_seconds: Option<u64>,
+    pub(crate) maximum_size: Option<u64>,
+}
+
+impl QuerySubmitOptions {
+    /// Creates an empty set of submit options.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets positional scalar bind parameters (`$1`, `$2`, ...) for the query.
+    #[must_use]
+    pub fn bindings(mut self, params: impl Into<QueryParameters>) -> Self {
+        self.bindings = Some(params.into());
+        self
+    }
+
+    /// Sets the maximum execution time, in seconds, before the server aborts
+    /// the query.
+    #[must_use]
+    pub fn timeout_seconds(mut self, seconds: u64) -> Self {
+        self.timeout_seconds = Some(seconds);
+        self
+    }
+
+    /// Sets the maximum materialized result size, in bytes.
+    #[must_use]
+    pub fn maximum_size(mut self, bytes: u64) -> Self {
+        self.maximum_size = Some(bytes);
+        self
+    }
 }
 
 /// The current status of an async query.
@@ -413,13 +473,19 @@ impl QueryHttpClient {
         }
     }
 
-    pub async fn submit(&self, sql: &str) -> Result<SubmitResponse, QueryError> {
+    pub async fn submit(
+        &self,
+        sql: &str,
+        parameters: Option<serde_json::Value>,
+        timeout_seconds: Option<u64>,
+        maximum_size: Option<u64>,
+    ) -> Result<SubmitResponse, QueryError> {
         let url = format!("{}/v1/queries", self.base_url);
         let body = SubmitRequest {
             sql: sql.to_string(),
-            parameters: None,
-            timeout_seconds: None,
-            maximum_size: None,
+            parameters,
+            timeout_seconds,
+            maximum_size,
         };
 
         let response = self


### PR DESCRIPTION
## Summary

Completes the async `/v1/queries` API for Spice **v2**. The API (added in #68/#70) already covered submit / list / status / results / cancel, but submit hardcoded `parameters`/`timeout_seconds`/`maximum_size` to `None`, so **parameterized async distributed queries** weren't exposed — even though the sync Flight path already has `sql_with_bindings`.

Verified against the handler at `spiceai/spiceai@v2.1.0` (`crates/runtime/src/http/v1/queries.rs`).

### New API

```rust
// Positional $1, $2, ... bindings (mirrors the sync sql_with_bindings):
let job = client.query_with_bindings(
    "SELECT * FROM large_table WHERE status = $1",
    QueryParameters::new().push("active"),
).await?;

// Bindings + submit controls:
let job = client.query_with_options(
    sql,
    QuerySubmitOptions::new()
        .bindings(QueryParameters::new().push("active"))
        .timeout_seconds(300)
        .maximum_size(100_000_000),
).await?;
```

- `QuerySubmitOptions` builder (`bindings`/`timeout_seconds`/`maximum_size`), exported from the crate root.
- `QueryParameters::to_json_values()` encodes scalar bindings as the JSON array the HTTP API expects; binary/array/non-finite params fail fast with `QueryError::InvalidParameter` before any request.
- `query(sql)` unchanged as the no-args shortcut.

## Tests

- `cargo test --lib` — **187 passed** (+9: 6 param-encoding unit tests incl. reject-binary/array/NaN, 3 wiremock tests asserting the exact request body).
- `cargo test --doc` — README + rustdoc examples compile.

## Note on #79

This branch is cut from the current (unformatted) `trunk`. #79 (`cargo fmt --all` + rustfmt CI gate) reformats pre-existing lines in `params.rs`/`client.rs`, so whichever of the two merges second will need a trivial rebase — I can handle that. My added code is already rustfmt-clean, so it will pass the new fmt gate once rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)