### PR TITLE
feat: add runtime_status and is_ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,43 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 }
 ```
 
+### Runtime health and status
+
+`is_ready()` is a single boolean for the whole runtime. When you need to know *which*
+component is not ready, `runtime_status()` reports each connection separately. Both use
+the HTTP API, so configure `http_url()`.
+
+```rust,no_run
+use spiceai::ClientBuilder;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+  let client = ClientBuilder::new()
+    .http_url("http://localhost:8090")
+    .build()
+    .await?;
+
+  if !client.is_ready().await? {
+    println!("runtime is not ready yet");
+  }
+
+  for component in client.runtime_status().await? {
+    println!("{} ({}): {}", component.name, component.endpoint, component.status);
+  }
+  // http (127.0.0.1:8090): Ready
+  // flight (127.0.0.1:50051): Ready
+  // metrics (N/A): Disabled
+  // opentelemetry (127.0.0.1:50051): Ready
+
+  Ok(())
+}
+```
+
+Each `ConnectionDetails` carries the component `name` (`http`, `flight`, `metrics` or
+`opentelemetry`), its `endpoint`, and its `status` — a `ComponentStatus` of `Initializing`,
+`Ready`, `Disabled`, `Error`, `Refreshing`, `ShuttingDown` or `NotLoaded`. A status a
+future runtime adds deserializes into `ComponentStatus::Other` rather than failing.
+
 ## Documentation
 
 Check out our [Documentation](https://docs.spice.ai/sdks/rust-sdk) to learn more about how to use the Rust SDK.

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,6 +6,7 @@ use crate::{
     config::{GenericError, SPICE_CLOUD_FLIGHT_ADDR, SPICE_LOCAL_FLIGHT_ADDR},
     dataset::{DatasetError, DatasetRefreshRequest, DatasetRefreshResponse},
     flight::{SqlFlightClient, is_connection_reset_generic_error},
+    status::{ConnectionDetails, StatusError},
     tls::{FlightChannelBuilder, ensure_crypto_provider, new_tls_flight_channel},
 };
 use arrow::record_batch::RecordBatch;
@@ -456,6 +457,53 @@ impl SpiceClient {
         })?;
 
         http_client.refresh_dataset(dataset_name, &request).await
+    }
+
+    /// Returns the status of each runtime connection.
+    ///
+    /// Backed by `GET /v1/status`. Where [`is_ready`](Self::is_ready) reports a single
+    /// boolean for the whole runtime, this reports `http`, `flight`, `metrics` and
+    /// `opentelemetry` individually, so it can say *which* component is not ready.
+    ///
+    /// **Note:** Requires [`http_url()`](SpiceClientBuilder::http_url) to be configured.
+    ///
+    /// ```no_run
+    /// # use spiceai::ClientBuilder;
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// let client = ClientBuilder::new()
+    ///     .http_url("http://localhost:8090")
+    ///     .build()
+    ///     .await?;
+    ///
+    /// for component in client.runtime_status().await? {
+    ///     println!("{} ({}): {}", component.name, component.endpoint, component.status);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn runtime_status(&self) -> Result<Vec<ConnectionDetails>, StatusError> {
+        let http_client = self
+            .http_client
+            .as_ref()
+            .ok_or(StatusError::HttpNotConfigured)?;
+
+        http_client.runtime_status().await
+    }
+
+    /// Returns whether the runtime is ready to serve queries.
+    ///
+    /// Backed by `GET /v1/ready`. Returns `Ok(false)` when the runtime responds that it
+    /// is not ready; an `Err` means the probe itself could not be completed.
+    ///
+    /// **Note:** Requires [`http_url()`](SpiceClientBuilder::http_url) to be configured.
+    pub async fn is_ready(&self) -> Result<bool, StatusError> {
+        let http_client = self
+            .http_client
+            .as_ref()
+            .ok_or(StatusError::HttpNotConfigured)?;
+
+        http_client.is_ready().await
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod dataset;
 mod flight;
 mod params;
 pub mod query;
+pub mod status;
 pub mod tls;
 mod util;
 
@@ -21,6 +22,7 @@ pub use query::{
     QueryError, QueryInfo, QueryJob, QueryListResponse, QueryResult, QueryResultStream,
     QueryStatus, QuerySummary,
 };
+pub use status::{ComponentStatus, ConnectionDetails, StatusError};
 
 // Further public exports and integrations
 pub use futures::StreamExt;

--- a/src/query.rs
+++ b/src/query.rs
@@ -406,6 +406,21 @@ impl QueryHttpClient {
         }
     }
 
+    /// The underlying reqwest client, for request builders constructed in sibling modules.
+    pub(crate) fn client(&self) -> &reqwest::Client {
+        &self.client
+    }
+
+    /// The runtime's HTTP base URL, with any trailing slash already trimmed.
+    pub(crate) fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Applies the configured API key to a request, if one is set.
+    pub(crate) fn authorized(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        self.add_auth(req)
+    }
+
     fn add_auth(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
         match &self.api_key {
             Some(key) => req.header("X-API-Key", key),

--- a/src/status.rs
+++ b/src/status.rs
@@ -20,8 +20,13 @@ pub enum StatusError {
     HttpNotConfigured,
 
     /// HTTP request failed with an error response.
-    #[snafu(display("Failed to get runtime status (HTTP {status_code}): {response_body}"))]
+    ///
+    /// Raised by both [`SpiceClient::runtime_status`] and [`SpiceClient::is_ready`],
+    /// so the message names the endpoint that failed rather than assuming either one.
+    #[snafu(display("Failed to query {url} (HTTP {status_code}): {response_body}"))]
     RequestFailed {
+        /// Endpoint that returned the error response.
+        url: String,
         /// HTTP status code returned by the server.
         status_code: u16,
         /// Response body from the server.
@@ -29,8 +34,12 @@ pub enum StatusError {
     },
 
     /// HTTP transport error.
-    #[snafu(display("Failed to get runtime status: {message}"))]
+    ///
+    /// Raised by both [`SpiceClient::runtime_status`] and [`SpiceClient::is_ready`].
+    #[snafu(display("Failed to query {url}: {message}"))]
     HttpError {
+        /// Endpoint that could not be reached.
+        url: String,
         /// Description of the transport failure.
         message: String,
     },
@@ -126,6 +135,7 @@ impl QueryHttpClient {
             .send()
             .await
             .map_err(|e| StatusError::HttpError {
+                url: url.clone(),
                 message: e.to_string(),
             })?;
 
@@ -136,6 +146,7 @@ impl QueryHttpClient {
             status_code => {
                 let response_body = response.text().await.unwrap_or_default();
                 Err(StatusError::RequestFailed {
+                    url,
                     status_code,
                     response_body,
                 })
@@ -152,6 +163,7 @@ impl QueryHttpClient {
             .send()
             .await
             .map_err(|e| StatusError::HttpError {
+                url: url.clone(),
                 message: e.to_string(),
             })?;
 
@@ -161,6 +173,7 @@ impl QueryHttpClient {
             status_code => {
                 let response_body = response.text().await.unwrap_or_default();
                 Err(StatusError::RequestFailed {
+                    url,
                     status_code,
                     response_body,
                 })
@@ -228,5 +241,29 @@ mod tests {
         assert_eq!(details[1].status, ComponentStatus::Initializing);
         assert!(!details[1].is_ready());
         assert_eq!(details[2].endpoint, "N/A");
+    }
+
+    #[test]
+    fn request_errors_name_the_endpoint_that_failed() {
+        // `RequestFailed`/`HttpError` are shared by `runtime_status` (/v1/status) and
+        // `is_ready` (/v1/ready), so the message has to say which one was being queried.
+        let request_failed = StatusError::RequestFailed {
+            url: "http://localhost:8090/v1/ready".to_string(),
+            status_code: 401,
+            response_body: "unauthorized".to_string(),
+        };
+        assert_eq!(
+            request_failed.to_string(),
+            "Failed to query http://localhost:8090/v1/ready (HTTP 401): unauthorized"
+        );
+
+        let http_error = StatusError::HttpError {
+            url: "http://localhost:8090/v1/status".to_string(),
+            message: "connection refused".to_string(),
+        };
+        assert_eq!(
+            http_error.to_string(),
+            "Failed to query http://localhost:8090/v1/status: connection refused"
+        );
     }
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,0 +1,232 @@
+//! Runtime health and per-component status.
+//!
+//! Two levels of detail are available. [`SpiceClient::is_ready`] is a single boolean
+//! for the whole runtime, backed by `GET /v1/ready`. [`SpiceClient::runtime_status`]
+//! reports the state of each connection individually, backed by `GET /v1/status`, and
+//! so can distinguish a runtime that is still initializing from one whose Flight
+//! endpoint is failing.
+
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+use std::fmt;
+
+use crate::query::QueryHttpClient;
+
+/// Errors returned when querying runtime health or status.
+#[derive(Debug, Snafu)]
+pub enum StatusError {
+    /// The HTTP endpoint was not configured on the client.
+    #[snafu(display("HTTP endpoint not configured. Use ClientBuilder::http_url() to set it."))]
+    HttpNotConfigured,
+
+    /// HTTP request failed with an error response.
+    #[snafu(display("Failed to get runtime status (HTTP {status_code}): {response_body}"))]
+    RequestFailed {
+        /// HTTP status code returned by the server.
+        status_code: u16,
+        /// Response body from the server.
+        response_body: String,
+    },
+
+    /// HTTP transport error.
+    #[snafu(display("Failed to get runtime status: {message}"))]
+    HttpError {
+        /// Description of the transport failure.
+        message: String,
+    },
+
+    /// Failed to parse the server response.
+    #[snafu(display("Failed to parse runtime status response: {message}"))]
+    ParseError {
+        /// Description of the parse failure.
+        message: String,
+    },
+}
+
+/// The state of a single runtime component.
+///
+/// Mirrors the runtime's `ComponentStatus`. Unknown variants are preserved in
+/// [`ComponentStatus::Other`] so that a newer runtime does not break deserialization.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ComponentStatus {
+    /// The component is initializing and not yet ready.
+    Initializing,
+    /// The component is ready to accept connections.
+    Ready,
+    /// The component is disabled and not running.
+    Disabled,
+    /// An error occurred in the component.
+    Error,
+    /// The component is refreshing its state.
+    Refreshing,
+    /// The component is shutting down.
+    ShuttingDown,
+    /// The component is configured but not loaded yet.
+    NotLoaded,
+    /// A status this version of the SDK does not know about.
+    #[serde(untagged)]
+    Other(String),
+}
+
+impl ComponentStatus {
+    /// Returns `true` if the component is ready to accept connections.
+    #[must_use]
+    pub fn is_ready(&self) -> bool {
+        matches!(self, ComponentStatus::Ready)
+    }
+
+    /// Returns `true` if the component is in an error state.
+    #[must_use]
+    pub fn is_error(&self) -> bool {
+        matches!(self, ComponentStatus::Error)
+    }
+}
+
+impl fmt::Display for ComponentStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ComponentStatus::Initializing => write!(f, "Initializing"),
+            ComponentStatus::Ready => write!(f, "Ready"),
+            ComponentStatus::Disabled => write!(f, "Disabled"),
+            ComponentStatus::Error => write!(f, "Error"),
+            ComponentStatus::Refreshing => write!(f, "Refreshing"),
+            ComponentStatus::ShuttingDown => write!(f, "ShuttingDown"),
+            ComponentStatus::NotLoaded => write!(f, "NotLoaded"),
+            ComponentStatus::Other(status) => write!(f, "{status}"),
+        }
+    }
+}
+
+/// The status of one runtime connection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConnectionDetails {
+    /// Name of the connection: `http`, `flight`, `metrics` or `opentelemetry`.
+    pub name: String,
+    /// Endpoint the connection is served on, or `N/A` when the component is disabled.
+    pub endpoint: String,
+    /// Status of the component.
+    pub status: ComponentStatus,
+}
+
+impl ConnectionDetails {
+    /// Returns `true` if this component is ready to accept connections.
+    #[must_use]
+    pub fn is_ready(&self) -> bool {
+        self.status.is_ready()
+    }
+}
+
+impl QueryHttpClient {
+    /// Fetches per-component runtime status from `GET /v1/status`.
+    pub(crate) async fn runtime_status(&self) -> Result<Vec<ConnectionDetails>, StatusError> {
+        let url = format!("{}/v1/status", self.base_url());
+
+        let response = self
+            .authorized(self.client().get(&url))
+            .send()
+            .await
+            .map_err(|e| StatusError::HttpError {
+                message: e.to_string(),
+            })?;
+
+        match response.status().as_u16() {
+            200 => response.json().await.map_err(|e| StatusError::ParseError {
+                message: e.to_string(),
+            }),
+            status_code => {
+                let response_body = response.text().await.unwrap_or_default();
+                Err(StatusError::RequestFailed {
+                    status_code,
+                    response_body,
+                })
+            }
+        }
+    }
+
+    /// Probes `GET /v1/ready`. `200` means ready, `503` means not ready.
+    pub(crate) async fn is_ready(&self) -> Result<bool, StatusError> {
+        let url = format!("{}/v1/ready", self.base_url());
+
+        let response = self
+            .authorized(self.client().get(&url))
+            .send()
+            .await
+            .map_err(|e| StatusError::HttpError {
+                message: e.to_string(),
+            })?;
+
+        match response.status().as_u16() {
+            200 => Ok(true),
+            503 => Ok(false),
+            status_code => {
+                let response_body = response.text().await.unwrap_or_default();
+                Err(StatusError::RequestFailed {
+                    status_code,
+                    response_body,
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_statuses_round_trip() {
+        for (json, expected) in [
+            ("\"Initializing\"", ComponentStatus::Initializing),
+            ("\"Ready\"", ComponentStatus::Ready),
+            ("\"Disabled\"", ComponentStatus::Disabled),
+            ("\"Error\"", ComponentStatus::Error),
+            ("\"Refreshing\"", ComponentStatus::Refreshing),
+            ("\"ShuttingDown\"", ComponentStatus::ShuttingDown),
+            ("\"NotLoaded\"", ComponentStatus::NotLoaded),
+        ] {
+            let parsed: ComponentStatus =
+                serde_json::from_str(json).expect("deserialize component status");
+            assert_eq!(parsed, expected);
+            assert_eq!(
+                serde_json::to_string(&parsed).expect("serialize component status"),
+                json
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_status_is_preserved() {
+        let parsed: ComponentStatus =
+            serde_json::from_str("\"SomethingNew\"").expect("deserialize unknown status");
+        assert_eq!(parsed, ComponentStatus::Other("SomethingNew".to_string()));
+        assert_eq!(parsed.to_string(), "SomethingNew");
+        assert!(!parsed.is_ready());
+    }
+
+    #[test]
+    fn status_predicates() {
+        assert!(ComponentStatus::Ready.is_ready());
+        assert!(!ComponentStatus::Initializing.is_ready());
+        assert!(ComponentStatus::Error.is_error());
+        assert!(!ComponentStatus::Ready.is_error());
+    }
+
+    #[test]
+    fn connection_details_deserialize() {
+        let body = r#"[
+            {"name":"http","endpoint":"127.0.0.1:8090","status":"Ready"},
+            {"name":"flight","endpoint":"127.0.0.1:50051","status":"Initializing"},
+            {"name":"metrics","endpoint":"N/A","status":"Disabled"}
+        ]"#;
+
+        let details: Vec<ConnectionDetails> =
+            serde_json::from_str(body).expect("deserialize connection details");
+
+        assert_eq!(details.len(), 3);
+        assert_eq!(details[0].name, "http");
+        assert!(details[0].is_ready());
+        assert_eq!(details[1].status, ComponentStatus::Initializing);
+        assert!(!details[1].is_ready());
+        assert_eq!(details[2].endpoint, "N/A");
+    }
+}


### PR DESCRIPTION
## What

Adds two runtime health methods to `SpiceClient`:

- `runtime_status()` → `Vec<ConnectionDetails>`, wrapping `GET /v1/status`. One entry
  per runtime connection (`http`, `flight`, `metrics`, `opentelemetry`) with that
  component's endpoint and `ComponentStatus`.
- `is_ready()` → `bool`, wrapping `GET /v1/ready`.

## Why

Neither endpoint was reachable from this SDK, so a Rust user waiting for a runtime to
come up — or diagnosing one that came up wrong — had to hand-roll `reqwest` calls
alongside the client they already had configured.

`/v1/ready` collapses the runtime to one boolean; `/v1/status` says *which* component
is not ready, which is the difference between "not up yet" and "Flight is failing".
Neither requires cluster mode or extra configuration, so both work on a default
`spice run`.

Two details worth a reviewer's eye:

- `ComponentStatus` has an `Other(String)` catch-all via `#[serde(untagged)]`, so a
  status variant added by a future runtime deserializes instead of erroring.
- `is_ready()` returns `Ok(false)` for the runtime's `503` and reserves `Err` for a
  probe that could not be completed, so "not ready" and "could not ask" stay distinct.

Adding `client()` / `base_url()` / `authorized()` accessors to the crate-private
`QueryHttpClient` lets `status.rs` reuse the existing client and API-key handling
rather than standing up a second `reqwest::Client`. No public API change there.

Part of aligning runtime health/status coverage across the Spice SDKs.

## Verification

- [x] `cargo build`
- [x] `cargo test --lib` — 182 passed, 0 failed (4 new)
- [x] `cargo test --doc` — 23 passed, including the new README example
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-features` — no new warnings
- [ ] Integration tests (`tests/client_test.rs`) — not run; they require a live runtime
      and `SCP_SPICEAI_TPCH_API_KEY`, neither available in this environment. They fail
      identically on unmodified `trunk` here.