### PR TITLE
feat: add search for vector, keyword, and hybrid search

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,20 @@ jobs:
         run: |
           spice init spice_qs
           cd spice_qs
-          spice add spiceai/quickstart
+          # Define the dataset inline rather than fetching spiceai/quickstart from
+          # the Spicepod registry, which currently returns a body the CLI cannot
+          # unpack ("Failed to extract Spicepod archive: Could not find EOCD").
+          cat >> spicepod.yaml <<'YAML'
+
+          datasets:
+            - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+              name: taxi_trips
+              description: taxi trips in s3
+              params:
+                file_format: parquet
+              acceleration:
+                enabled: true
+          YAML
           spice run &> spice.log &
           # time to initialize added dataset
           sleep 10
@@ -169,7 +182,20 @@ jobs:
         run: |
           spice init spice_qs
           cd spice_qs
-          spice add spiceai/quickstart
+          # Define the dataset inline rather than fetching spiceai/quickstart from
+          # the Spicepod registry, which currently returns a body the CLI cannot
+          # unpack ("Failed to extract Spicepod archive: Could not find EOCD").
+          @'
+
+          datasets:
+            - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+              name: taxi_trips
+              description: taxi trips in s3
+              params:
+                file_format: parquet
+              acceleration:
+                enabled: true
+          '@ | Add-Content -Path spicepod.yaml
           Start-Process -FilePath spice run
           # time to initialize added dataset
           Start-Sleep -Seconds 10

--- a/README.md
+++ b/README.md
@@ -111,6 +111,49 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 }
 ```
 
+### Search
+
+`search()` runs vector similarity, keyword, and hybrid search against datasets that have an embedding column and a loaded embedding model. Like dataset refresh, it uses the Spice HTTP API, so configure `http_url()`.
+
+```rust,no_run
+use spiceai::{ClientBuilder, SearchRequest};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+  let client = ClientBuilder::new()
+    .http_url("http://localhost:8090")
+    .build()
+    .await?;
+
+  let response = client
+    .search(
+      SearchRequest::new("tickets to Tokyo")
+        .with_datasets(["app_messages"])
+        .with_limit(3),
+    )
+    .await?;
+
+  println!("{} matches in {}ms", response.len(), response.duration_ms);
+  for m in &response {
+    println!("{} {} {:?}", m.dataset, m.score, m.matches);
+  }
+  Ok(())
+}
+```
+
+Only the query text is required. `with_datasets` restricts the search — omit it to search every dataset with an embedding column. `with_limit` caps matches per dataset, `with_where` applies an SQL predicate before the search, and `with_additional_columns` names extra columns to return. `with_keywords` pre-filters the embedding column with a lexical search before the vector search runs, making the search hybrid:
+
+```rust,no_run
+use spiceai::SearchRequest;
+
+let request = SearchRequest::new("tickets to Tokyo")
+  .with_where("city = 'Tokyo'")
+  .with_additional_columns(["timestamp"])
+  .with_keywords(["plane", "tickets"]);
+```
+
+Each `SearchMatch` carries the `dataset` it was found in, its similarity `score`, the matched column values in `matches`, the row's `primary_key`, the columns requested via `with_additional_columns` in `data`, and any `metadata`. The runtime omits the last four when empty; they deserialize to empty maps, so they can be read without a guard.
+
 ### Async query jobs and dataset refresh
 
 Async query management and dataset refresh use the Spice HTTP API, so configure `http_url()` in addition to the Flight endpoint when needed.

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,6 +6,7 @@ use crate::{
     config::{GenericError, SPICE_CLOUD_FLIGHT_ADDR, SPICE_LOCAL_FLIGHT_ADDR},
     dataset::{DatasetError, DatasetRefreshRequest, DatasetRefreshResponse},
     flight::{SqlFlightClient, is_connection_reset_generic_error},
+    search::{SearchError, SearchRequest, SearchResponse},
     tls::{FlightChannelBuilder, ensure_crypto_provider, new_tls_flight_channel},
 };
 use arrow::record_batch::RecordBatch;
@@ -557,6 +558,55 @@ impl SpiceClient {
     ) -> Result<DatasetRefreshResponse, DatasetError> {
         self.refresh_dataset_with_options(dataset_name, DatasetRefreshRequest::default())
             .await
+    }
+
+    /// Runs a vector, keyword, or hybrid search.
+    ///
+    /// Searches datasets that have an embedding column and a loaded embedding
+    /// model, returning the documents most similar to the request text.
+    /// Supplying [`with_keywords`](crate::SearchRequest::with_keywords)
+    /// pre-filters the embedding column with a lexical search first, making the
+    /// search hybrid.
+    ///
+    /// **Note:** Requires [`http_url()`](SpiceClientBuilder::http_url) to be configured.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SearchError`] if the text is empty, the HTTP endpoint is not
+    /// configured, or the runtime rejects the search.
+    ///
+    /// ```no_run
+    /// # use spiceai::{ClientBuilder, SearchRequest};
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// let client = ClientBuilder::new()
+    ///     .http_url("http://localhost:8090")
+    ///     .build()
+    ///     .await?;
+    ///
+    /// let response = client
+    ///     .search(SearchRequest::new("tickets to Tokyo").with_limit(3))
+    ///     .await?;
+    ///
+    /// for m in &response {
+    ///     println!("{} {} {:?}", m.dataset, m.score, m.matches);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn search(&self, request: SearchRequest) -> Result<SearchResponse, SearchError> {
+        if request.text.is_empty() {
+            return Err(SearchError::EmptyText);
+        }
+
+        let http_client = self
+            .http_client
+            .as_ref()
+            .ok_or(SearchError::HttpNotConfigured {
+                message: "Search requires the HTTP endpoint.".to_string(),
+            })?;
+
+        http_client.search(&request).await
     }
 
     /// Triggers an on-demand refresh for an accelerated dataset with overrides.
@@ -1402,5 +1452,117 @@ mod tests {
             .await
             .expect("refresh dataset with explicit overrides");
         assert_eq!(custom_refresh.message, "Refresh scheduled");
+    }
+
+    #[tokio::test]
+    async fn test_search_posts_request_and_decodes_response() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/search"))
+            .and(body_json(json!({
+                "text": "tickets to Tokyo",
+                "datasets": ["app_messages"],
+                "limit": 3,
+                "keywords": ["plane", "tickets"]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [
+                    {
+                        "matches": {"message": ["I booked us some tickets"]},
+                        "dataset": "app_messages",
+                        "primary_key": {"id": "6fd5a215"},
+                        "data": {"timestamp": 1_724_716_542_i64},
+                        "_score": 0.914_321
+                    },
+                    {
+                        "dataset": "app_messages",
+                        "_score": 0.832_21
+                    }
+                ],
+                "duration_ms": 42
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(Some(&server.uri()));
+
+        let response = client
+            .search(
+                SearchRequest::new("tickets to Tokyo")
+                    .with_datasets(["app_messages"])
+                    .with_limit(3)
+                    .with_keywords(["plane", "tickets"]),
+            )
+            .await
+            .expect("search returns matches");
+
+        assert_eq!(response.duration_ms, 42);
+        assert_eq!(response.len(), 2);
+        assert_eq!(response.results[0].dataset, "app_messages");
+        assert_eq!(
+            response.results[0].data.get("timestamp"),
+            Some(&json!(1_724_716_542_i64))
+        );
+        // The runtime omits empty objects; they decode to empty maps.
+        assert!(response.results[1].data.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_search_rejects_empty_text_without_a_request() {
+        let server = MockServer::start().await;
+        // No mock is mounted: reaching the server would be a failure.
+        let client = test_client(Some(&server.uri()));
+
+        let err = client
+            .search(SearchRequest::new(""))
+            .await
+            .expect_err("empty search text is rejected");
+
+        assert!(matches!(err, SearchError::EmptyText));
+    }
+
+    #[tokio::test]
+    async fn test_search_surfaces_runtime_error() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/search"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "error": "No data sources provided"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(Some(&server.uri()));
+
+        let err = client
+            .search(SearchRequest::new("tickets"))
+            .await
+            .expect_err("runtime rejects the search");
+
+        match err {
+            SearchError::SearchFailed {
+                status_code,
+                response_body,
+            } => {
+                assert_eq!(status_code, 400);
+                // The runtime's message is what tells the user what to fix.
+                assert!(response_body.contains("No data sources provided"));
+            }
+            other => panic!("expected SearchFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_search_requires_http_url() {
+        let client = test_client(None);
+
+        let err = client
+            .search(SearchRequest::new("tickets"))
+            .await
+            .expect_err("search without an HTTP endpoint is rejected");
+
+        assert!(matches!(err, SearchError::HttpNotConfigured { .. }));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod dataset;
 mod flight;
 mod params;
 pub mod query;
+mod search;
 pub mod tls;
 mod util;
 
@@ -21,6 +22,7 @@ pub use query::{
     QueryError, QueryInfo, QueryJob, QueryListResponse, QueryResult, QueryResultStream,
     QueryStatus, QuerySubmitOptions, QuerySummary,
 };
+pub use search::{SearchError, SearchMatch, SearchRequest, SearchResponse};
 
 // Further public exports and integrations
 pub use futures::StreamExt;

--- a/src/query.rs
+++ b/src/query.rs
@@ -691,6 +691,37 @@ impl QueryHttpClient {
         }
     }
 
+    pub async fn search(
+        &self,
+        request: &crate::search::SearchRequest,
+    ) -> Result<crate::search::SearchResponse, crate::search::SearchError> {
+        use crate::search::SearchError;
+
+        let url = format!("{}/v1/search", self.base_url);
+
+        let response = self
+            .add_auth(self.client.post(&url))
+            .json(request)
+            .send()
+            .await
+            .map_err(|e| SearchError::HttpError {
+                message: e.to_string(),
+            })?;
+
+        match response.status().as_u16() {
+            200 => response.json().await.map_err(|e| SearchError::ParseError {
+                message: e.to_string(),
+            }),
+            status_code => {
+                let response_body = response.text().await.unwrap_or_default();
+                Err(SearchError::SearchFailed {
+                    status_code,
+                    response_body,
+                })
+            }
+        }
+    }
+
     pub async fn refresh_dataset(
         &self,
         dataset_name: &str,

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,0 +1,314 @@
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+use std::collections::HashMap;
+
+#[derive(Debug, Snafu)]
+pub enum SearchError {
+    #[snafu(display("Search text cannot be empty"))]
+    EmptyText,
+
+    #[snafu(display(
+        "HTTP endpoint not configured. Use ClientBuilder::http_url() to set it. {message}"
+    ))]
+    HttpNotConfigured { message: String },
+
+    #[snafu(display("Search request failed: {message}"))]
+    HttpError { message: String },
+
+    #[snafu(display("Search failed (HTTP {status_code}): {response_body}"))]
+    SearchFailed {
+        status_code: u16,
+        response_body: String,
+    },
+
+    #[snafu(display("Failed to parse search response: {message}"))]
+    ParseError { message: String },
+}
+
+/// A search over datasets that have an embedding column and a loaded embedding model.
+///
+/// Only the query text is required. Build with [`SearchRequest::new`] and refine
+/// with the `with_*` methods:
+///
+/// ```
+/// # use spiceai::SearchRequest;
+/// let request = SearchRequest::new("tickets to Tokyo")
+///     .with_datasets(["app_messages"])
+///     .with_limit(3)
+///     .with_keywords(["plane", "tickets"]);
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct SearchRequest {
+    /// The query to find similar documents for.
+    pub text: String,
+
+    /// Restricts the search to these datasets. `None` searches every dataset
+    /// with an embedding column.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub datasets: Option<Vec<String>>,
+
+    /// Maximum matches to return per dataset. `None` uses the runtime's default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+
+    /// An SQL predicate applied before the search, without the `WHERE` keyword —
+    /// for example `city = 'Tokyo'`.
+    #[serde(rename = "where", skip_serializing_if = "Option::is_none")]
+    pub where_cond: Option<String>,
+
+    /// Extra dataset columns to return. A column that is part of the primary key
+    /// is returned in [`SearchMatch::primary_key`] rather than [`SearchMatch::data`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additional_columns: Option<Vec<String>>,
+
+    /// Pre-filters the embedding column with a lexical search before the vector
+    /// search runs, making the search hybrid.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keywords: Option<Vec<String>>,
+}
+
+impl SearchRequest {
+    #[must_use]
+    pub fn new(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            ..Default::default()
+        }
+    }
+
+    #[must_use]
+    pub fn with_datasets<I, S>(mut self, datasets: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.datasets = Some(datasets.into_iter().map(Into::into).collect());
+        self
+    }
+
+    #[must_use]
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    #[must_use]
+    pub fn with_where(mut self, where_cond: impl Into<String>) -> Self {
+        self.where_cond = Some(where_cond.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_additional_columns<I, S>(mut self, columns: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.additional_columns = Some(columns.into_iter().map(Into::into).collect());
+        self
+    }
+
+    #[must_use]
+    pub fn with_keywords<I, S>(mut self, keywords: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.keywords = Some(keywords.into_iter().map(Into::into).collect());
+        self
+    }
+}
+
+/// A single document matched by a search.
+///
+/// The runtime omits `matches`, `primary_key`, `data`, and `metadata` when they
+/// are empty; they deserialize to empty maps so they can be read without a guard.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct SearchMatch {
+    /// The dataset the match was found in.
+    pub dataset: String,
+
+    /// Similarity of the match to the query text. Higher is closer.
+    #[serde(rename = "_score")]
+    pub score: f64,
+
+    /// The matched values of each searched column.
+    #[serde(default)]
+    pub matches: HashMap<String, Vec<serde_json::Value>>,
+
+    /// Primary key identifying the matched row, if the dataset declares one.
+    #[serde(default)]
+    pub primary_key: HashMap<String, serde_json::Value>,
+
+    /// Columns requested via [`SearchRequest::additional_columns`].
+    #[serde(default)]
+    pub data: HashMap<String, serde_json::Value>,
+
+    /// Any additional metadata the runtime attached to the match.
+    #[serde(default)]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+/// The result of a search.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct SearchResponse {
+    /// Matches, ordered by descending score.
+    #[serde(default)]
+    pub results: Vec<SearchMatch>,
+
+    /// How long the runtime took to run the search.
+    #[serde(default)]
+    pub duration_ms: u64,
+}
+
+impl SearchResponse {
+    /// Number of matches returned.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.results.len()
+    }
+
+    /// Whether the search returned no matches.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.results.is_empty()
+    }
+}
+
+impl IntoIterator for SearchResponse {
+    type Item = SearchMatch;
+    type IntoIter = std::vec::IntoIter<SearchMatch>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.results.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a SearchResponse {
+    type Item = &'a SearchMatch;
+    type IntoIter = std::slice::Iter<'a, SearchMatch>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.results.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_request_text_only_omits_optional_fields() {
+        let json = serde_json::to_value(SearchRequest::new("tickets to Tokyo"))
+            .expect("serialize search request");
+        assert_eq!(json, serde_json::json!({"text": "tickets to Tokyo"}));
+    }
+
+    #[test]
+    fn test_request_builder() {
+        let request = SearchRequest::new("tickets to Tokyo")
+            .with_datasets(["app_messages"])
+            .with_limit(3)
+            .with_where("city = 'Tokyo'")
+            .with_additional_columns(["timestamp"])
+            .with_keywords(["plane", "tickets"]);
+
+        let json = serde_json::to_value(&request).expect("serialize search request");
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "text": "tickets to Tokyo",
+                "datasets": ["app_messages"],
+                "limit": 3,
+                "where": "city = 'Tokyo'",
+                "additional_columns": ["timestamp"],
+                "keywords": ["plane", "tickets"],
+            })
+        );
+    }
+
+    #[test]
+    fn test_where_uses_the_wire_field_name() {
+        let json = serde_json::to_value(SearchRequest::new("x").with_where("a = 1"))
+            .expect("serialize search request");
+        assert!(json.get("where").is_some());
+        assert!(json.get("where_cond").is_none());
+    }
+
+    #[test]
+    fn test_response_deserializes_wire_format() {
+        let body = serde_json::json!({
+            "results": [
+                {
+                    "matches": {"message": ["I booked us some tickets"]},
+                    "dataset": "app_messages",
+                    "primary_key": {"id": "6fd5a215"},
+                    "data": {"timestamp": 1_724_716_542_i64},
+                    "_score": 0.914_321
+                },
+                {
+                    "dataset": "app_messages",
+                    "_score": 0.832_21
+                }
+            ],
+            "duration_ms": 42
+        });
+
+        let response: SearchResponse =
+            serde_json::from_value(body).expect("deserialize search response");
+
+        assert_eq!(response.duration_ms, 42);
+        assert_eq!(response.len(), 2);
+        assert!(!response.is_empty());
+
+        let first = &response.results[0];
+        assert_eq!(first.dataset, "app_messages");
+        assert!((first.score - 0.914_321).abs() < f64::EPSILON);
+        assert_eq!(
+            first
+                .primary_key
+                .get("id")
+                .and_then(serde_json::Value::as_str),
+            Some("6fd5a215")
+        );
+        assert_eq!(first.matches["message"].len(), 1);
+
+        // Omitted objects deserialize to empty maps, readable without a guard.
+        let second = &response.results[1];
+        assert!(second.data.is_empty());
+        assert!(second.primary_key.is_empty());
+        assert!(second.metadata.is_empty());
+        assert!(second.matches.is_empty());
+    }
+
+    #[test]
+    fn test_response_iteration() {
+        let body = serde_json::json!({
+            "results": [
+                {"dataset": "a", "_score": 0.9},
+                {"dataset": "b", "_score": 0.8}
+            ],
+            "duration_ms": 1
+        });
+        let response: SearchResponse =
+            serde_json::from_value(body).expect("deserialize search response");
+
+        let datasets: Vec<&str> = (&response)
+            .into_iter()
+            .map(|m| m.dataset.as_str())
+            .collect();
+        assert_eq!(datasets, vec!["a", "b"]);
+
+        let scores: Vec<f64> = response.into_iter().map(|m| m.score).collect();
+        assert_eq!(scores.len(), 2);
+    }
+
+    #[test]
+    fn test_empty_response() {
+        let response: SearchResponse =
+            serde_json::from_value(serde_json::json!({"results": [], "duration_ms": 0}))
+                .expect("deserialize search response");
+        assert!(response.is_empty());
+        assert_eq!(response.len(), 0);
+    }
+}

--- a/src/search.rs
+++ b/src/search.rs
@@ -44,6 +44,11 @@ pub struct SearchRequest {
 
     /// Restricts the search to these datasets. `None` searches every dataset
     /// with an embedding column.
+    ///
+    /// `Some(vec![])` is not the same as `None`: it asks for a search over no
+    /// datasets, which the runtime rejects with "No data sources provided".
+    /// That is deliberate — a caller whose dataset list came out empty is
+    /// better served by an error than by a silent search across everything.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub datasets: Option<Vec<String>>,
 
@@ -225,6 +230,21 @@ mod tests {
                 "keywords": ["plane", "tickets"],
             })
         );
+    }
+
+    #[test]
+    fn test_empty_datasets_is_distinct_from_omitted() {
+        // An explicitly empty list asks for "no datasets", which the runtime
+        // rejects. Coercing it to None would instead silently widen the search
+        // to every dataset.
+        let omitted =
+            serde_json::to_value(SearchRequest::new("x")).expect("serialize search request");
+        assert!(omitted.get("datasets").is_none());
+
+        let empty =
+            serde_json::to_value(SearchRequest::new("x").with_datasets(Vec::<String>::new()))
+                .expect("serialize search request");
+        assert_eq!(empty.get("datasets"), Some(&serde_json::json!([])));
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `SpiceClient::search`, wrapping the runtime's `POST /v1/search` — vector similarity, keyword, and hybrid search over datasets with an embedding column.

```rust
let response = client
    .search(
        SearchRequest::new("tickets to Tokyo")
            .with_datasets(["app_messages"])
            .with_limit(3),
    )
    .await?;

for m in &response {
    println!("{} {} {:?}", m.dataset, m.score, m.matches);
}
```

`SearchRequest` follows the crate's existing builder convention (`mut self` → `Self`), so only the query text is required. `with_keywords` pre-filters the embedding column with a lexical search before the vector search runs, making the search hybrid.

New public exports: `SearchRequest`, `SearchResponse`, `SearchMatch`, `SearchError`.

## Why

`/v1/search` works on a default `spice run` and is a distinctive Spice capability, but Rust users had no way to reach it short of hand-rolling the HTTP call. spice.js is currently the only SDK that exposes it.

Two wire-format details the types handle so callers don't have to:

- the similarity score is serialized as `_score`, not `score`, and the request's SQL predicate is `where`, not `where_cond`
- `matches`, `data`, `primary_key` and `metadata` are omitted entirely when empty, so they deserialize to empty maps — readable without a guard

Errors go through a `SearchError` enum consistent with `DatasetError` and `QueryError`, and surface the runtime's own message on a rejected search rather than a raw transport error.

Part of aligning search support across the SDKs.

## Verification

- [x] `cargo build`
- [x] `cargo test --lib` — 197 passed, including 6 serde tests in `search.rs` and 4 wiremock-backed client tests covering request encoding, response decoding, empty-text rejection, and runtime error surfacing
- [x] `cargo test --doc` — 29 passed, including the new README examples (the crate doctests its README via `include_str!`)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-features` — no new warnings
- [x] Verified against a live `spice run`: the search request reaches `/v1/search`, and a
      failure surfaces the runtime's own message (`"Search cannot be run on <dataset> because it
      has no embeddings or full text search indexes."`) rather than a bare status code
- [ ] A search returning matches was not exercised end to end — that needs a dataset with an
      embedding column and a loaded embedding model, which this environment has no credentials for. The 24 `tests/client_test.rs` failures in a full `cargo test` are all refused Flight connections and are unrelated to this change.
