### PR TITLE
ci: define the test dataset inline instead of fetching it from the registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,20 @@ jobs:
         run: |
           spice init spice_qs
           cd spice_qs
-          spice add spiceai/quickstart
+          # Define the dataset inline rather than fetching spiceai/quickstart from
+          # the Spicepod registry, which currently returns a body the CLI cannot
+          # unpack ("Failed to extract Spicepod archive: Could not find EOCD").
+          cat >> spicepod.yaml <<'YAML'
+
+          datasets:
+            - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+              name: taxi_trips
+              description: taxi trips in s3
+              params:
+                file_format: parquet
+              acceleration:
+                enabled: true
+          YAML
           spice run &> spice.log &
           # time to initialize added dataset
           sleep 10
@@ -169,7 +182,20 @@ jobs:
         run: |
           spice init spice_qs
           cd spice_qs
-          spice add spiceai/quickstart
+          # Define the dataset inline rather than fetching spiceai/quickstart from
+          # the Spicepod registry, which currently returns a body the CLI cannot
+          # unpack ("Failed to extract Spicepod archive: Could not find EOCD").
+          @'
+
+          datasets:
+            - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+              name: taxi_trips
+              description: taxi trips in s3
+              params:
+                file_format: parquet
+              acceleration:
+                enabled: true
+          '@ | Add-Content -Path spicepod.yaml
           Start-Process -FilePath spice run
           # time to initialize added dataset
           Start-Sleep -Seconds 10


### PR DESCRIPTION
## What

Replaces `spice add spiceai/quickstart` with the same dataset declared inline, in both the Unix step (heredoc) and the Windows step (PowerShell here-string).

## Why

Every `Build and test` job dies before a test runs:

```
ERROR Invalid argument: Failed to extract Spicepod archive: invalid Zip archive: Could not find EOCD
```

The Spicepod registry is returning a body the CLI can't unpack. `Clippy` and `rustfmt` stay green because they don't need a runtime — only the jobs that start one fail, which is the signature of an environment problem rather than a code one.

This reproduces off CI: `spice add spiceai/quickstart` fails identically on a local machine.

Mirrors [spicepy#176](https://github.com/spiceai/spicepy/pull/176), which is green.

## Verification

- [x] Ran the resulting spicepod against a local runtime — `taxi_trips` queryable in ~6s, 2,964,624 rows
- [x] Workflow YAML parses
- [x] Checked the dedented form each shell actually receives: the bash heredoc and the PowerShell here-string both come out correct, with `'@` at column 0 as PowerShell requires
- [x] `spice init` emits `version: v2`