### PR TITLE
feat: add search for the runtime's /v1/search endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,41 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 }
 ```
 
+### Search
+
+`search` finds documents similar to a piece of text using the runtime's `/v1/search` endpoint. It runs against datasets that have an embedding column and a loaded embedding model — see [Search & Retrieval](https://docs.spice.ai/features/search-and-retrieval) for how to configure them. Like dataset refresh, it uses the HTTP API, so `http_url()` must be configured.
+
+```rust,no_run
+use spiceai::{ClientBuilder, SearchRequest};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+  let client = ClientBuilder::new()
+    .http_url("http://localhost:8090")
+    .build()
+    .await?;
+
+  let response = client
+    .search(
+      SearchRequest::new("tokyo plane tickets")
+        .with_datasets(["app_messages"])
+        .with_limit(3)
+        .with_additional_columns(["timestamp"]),
+    )
+    .await?;
+
+  println!("{} matches in {}ms", response.len(), response.duration_ms);
+  for m in response {
+    println!("{} {} {:?}", m.score, m.dataset, m.matches);
+  }
+  Ok(())
+}
+```
+
+Adding `with_keywords([...])` runs a lexical pass alongside the vector pass, which the runtime combines into a single hybrid ranking. `with_where("user_id = 42")` filters candidate rows with a SQL predicate.
+
+Each `SearchMatch` carries `dataset`, `score` (higher is more similar), `matches` (matched values keyed by source column — a list per column, since one column can contribute several chunks to a match), `primary_key`, `data`, and `metadata`.
+
 ## Documentation
 
 Check out our [Documentation](https://docs.spice.ai/sdks/rust-sdk) to learn more about how to use the Rust SDK.

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,6 +6,7 @@ use crate::{
     config::{GenericError, SPICE_CLOUD_FLIGHT_ADDR, SPICE_LOCAL_FLIGHT_ADDR},
     dataset::{DatasetError, DatasetRefreshRequest, DatasetRefreshResponse},
     flight::{SqlFlightClient, is_connection_reset_generic_error},
+    search::{SearchError, SearchRequest, SearchResponse},
     tls::{FlightChannelBuilder, ensure_crypto_provider, new_tls_flight_channel},
 };
 use arrow::record_batch::RecordBatch;
@@ -574,6 +575,55 @@ impl SpiceClient {
         })?;
 
         http_client.refresh_dataset(dataset_name, &request).await
+    }
+
+    /// Searches datasets for documents similar to the request's text.
+    ///
+    /// Runs against datasets that have an embedding column and a loaded
+    /// embedding model — see [Search & Retrieval](https://docs.spice.ai/features/search-and-retrieval)
+    /// for how to configure them. Adding keywords to the request turns this
+    /// into a hybrid search, combining a lexical pass with the vector scores.
+    ///
+    /// **Note:** Requires [`http_url()`](SpiceClientBuilder::http_url) to be configured.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use spiceai::{ClientBuilder, SearchRequest};
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// let client = ClientBuilder::new()
+    ///     .http_url("http://localhost:8090")
+    ///     .build()
+    ///     .await?;
+    ///
+    /// let response = client
+    ///     .search(
+    ///         SearchRequest::new("tokyo plane tickets")
+    ///             .with_datasets(["app_messages"])
+    ///             .with_limit(3),
+    ///     )
+    ///     .await?;
+    ///
+    /// for m in response {
+    ///     println!("{} {} {:?}", m.score, m.dataset, m.matches);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// - [`SearchError::InvalidRequest`] if the request has empty text or a zero limit
+    /// - [`SearchError::HttpError`] if the HTTP endpoint is not configured or unreachable
+    /// - [`SearchError::SearchFailed`] if the runtime rejects the search
+    pub async fn search(&self, request: SearchRequest) -> Result<SearchResponse, SearchError> {
+        let http_client = self.http_client.as_ref().ok_or(SearchError::HttpError {
+            message: "HTTP endpoint not configured. Use ClientBuilder::http_url() to set it."
+                .to_string(),
+        })?;
+
+        http_client.search(&request).await
     }
 }
 
@@ -1402,5 +1452,117 @@ mod tests {
             .await
             .expect("refresh dataset with explicit overrides");
         assert_eq!(custom_refresh.message, "Refresh scheduled");
+    }
+
+    #[tokio::test]
+    async fn test_search_posts_request_and_parses_response() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/search"))
+            .and(body_json(json!({
+                "text": "tokyo plane tickets",
+                "datasets": ["app_messages"],
+                "limit": 3,
+                "additional_columns": ["timestamp"],
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [
+                    {
+                        "matches": {"message": ["I booked us some tickets", "direct to Narita"]},
+                        "dataset": "app_messages",
+                        "primary_key": {"id": "6fd5a215"},
+                        "data": {"timestamp": 1_724_716_542_i64},
+                        "_score": 0.914_321
+                    },
+                    {
+                        "matches": {"message": ["we're sitting together"]},
+                        "dataset": "app_messages",
+                        "_score": 0.787_654
+                    }
+                ],
+                "duration_ms": 42
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(Some(&server.uri()));
+
+        let response = client
+            .search(
+                SearchRequest::new("tokyo plane tickets")
+                    .with_datasets(["app_messages"])
+                    .with_limit(3)
+                    .with_additional_columns(["timestamp"]),
+            )
+            .await
+            .expect("search succeeds");
+
+        assert_eq!(response.duration_ms, 42);
+        assert_eq!(response.len(), 2);
+
+        let first = &response.results[0];
+        assert_eq!(first.dataset, "app_messages");
+        // One column can contribute several chunks to a single match.
+        assert_eq!(first.matches["message"].len(), 2);
+        assert_eq!(first.data["timestamp"], 1_724_716_542_i64);
+
+        // The runtime omits data and primary_key when they are empty.
+        assert!(response.results[1].data.is_empty());
+        assert!(response.results[1].primary_key.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_search_surfaces_runtime_error_body() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/search"))
+            .respond_with(ResponseTemplate::new(400).set_body_string("No data sources provided"))
+            .mount(&server)
+            .await;
+
+        let client = test_client(Some(&server.uri()));
+
+        let err = client
+            .search(SearchRequest::new("tokyo"))
+            .await
+            .expect_err("runtime rejects the search");
+
+        let message = err.to_string();
+        assert!(message.contains("No data sources provided"), "{message}");
+        assert!(message.contains("400"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn test_search_validates_before_sending() {
+        let server = MockServer::start().await;
+        // No mock is mounted: a request reaching the server fails the test.
+        let client = test_client(Some(&server.uri()));
+
+        let err = client
+            .search(SearchRequest::new(""))
+            .await
+            .expect_err("empty text is rejected");
+        assert!(err.to_string().contains("non-empty"), "{err}");
+
+        assert!(
+            server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_search_requires_http_url() {
+        let client = test_client(None);
+
+        let err = client
+            .search(SearchRequest::new("tokyo"))
+            .await
+            .expect_err("search without an HTTP endpoint fails");
+        assert!(err.to_string().contains("http_url"), "{err}");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod dataset;
 mod flight;
 mod params;
 pub mod query;
+pub mod search;
 pub mod tls;
 mod util;
 
@@ -21,6 +22,7 @@ pub use query::{
     QueryError, QueryInfo, QueryJob, QueryListResponse, QueryResult, QueryResultStream,
     QueryStatus, QuerySubmitOptions, QuerySummary,
 };
+pub use search::{SearchError, SearchMatch, SearchRequest, SearchResponse};
 
 // Further public exports and integrations
 pub use futures::StreamExt;

--- a/src/query.rs
+++ b/src/query.rs
@@ -35,6 +35,7 @@
 
 use crate::dataset::{DatasetError, DatasetRefreshRequest, DatasetRefreshResponse};
 use crate::params::{QueryParameterError, QueryParameters};
+use crate::search::{SearchError, SearchRequest, SearchResponse};
 use arrow::array::RecordBatch;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use futures::Stream;
@@ -756,6 +757,36 @@ impl QueryHttpClient {
                 })
             }
         }
+    }
+
+    pub async fn search(&self, request: &SearchRequest) -> Result<SearchResponse, SearchError> {
+        request.validate()?;
+
+        let url = format!("{}/v1/search", self.base_url);
+
+        let response = self
+            .add_auth(self.client.post(&url))
+            .json(request)
+            .send()
+            .await
+            .map_err(|e| SearchError::HttpError {
+                message: e.to_string(),
+            })?;
+
+        let status_code = response.status().as_u16();
+        if status_code != 200 {
+            // The runtime explains search failures in a plain-text body ("No
+            // data sources provided"). Surface it, not just the status code.
+            let response_body = response.text().await.unwrap_or_default();
+            return Err(SearchError::SearchFailed {
+                status_code,
+                response_body: response_body.trim().to_string(),
+            });
+        }
+
+        response.json().await.map_err(|e| SearchError::ParseError {
+            message: e.to_string(),
+        })
     }
 
     /// List queries with optional status filter and limit.

--- a/src/query.rs
+++ b/src/query.rs
@@ -792,10 +792,17 @@ impl QueryHttpClient {
         if status_code != 200 {
             // The runtime explains search failures in a plain-text body ("No
             // data sources provided"). Surface it, not just the status code.
-            let response_body = response.text().await.unwrap_or_default();
+            let response_body = match response.text().await {
+                Ok(body) => body.trim().to_string(),
+                // The status code is already known, so a body that cannot be read
+                // reports why instead of collapsing to an empty string — otherwise
+                // the transport failure is lost and the error reads as if the
+                // runtime had explained nothing.
+                Err(e) => format!("<error body could not be read: {e}>"),
+            };
             return Err(SearchError::SearchFailed {
                 status_code,
-                response_body: response_body.trim().to_string(),
+                response_body,
             });
         }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,0 +1,333 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+
+/// Errors returned when searching.
+#[derive(Debug, Snafu)]
+pub enum SearchError {
+    /// The search request was rejected before being sent.
+    #[snafu(display("Invalid search request: {message}"))]
+    InvalidRequest { message: String },
+
+    /// The runtime rejected the search.
+    #[snafu(display("Search failed (HTTP {status_code}): {response_body}"))]
+    SearchFailed {
+        /// HTTP status code returned by the server.
+        status_code: u16,
+        /// Response body from the server.
+        response_body: String,
+    },
+
+    /// HTTP transport error.
+    #[snafu(display("Search failed: {message}"))]
+    HttpError { message: String },
+
+    /// Failed to parse the server response.
+    #[snafu(display("Failed to parse search response: {message}"))]
+    ParseError { message: String },
+}
+
+/// A search against the runtime's `/v1/search` endpoint.
+///
+/// Only the search text is required. Adding keywords turns the search into a
+/// hybrid one: the runtime runs a lexical pass alongside the vector pass and
+/// combines the scores into a single ranking.
+///
+/// ```
+/// use spiceai::SearchRequest;
+///
+/// let request = SearchRequest::new("tokyo plane tickets")
+///     .with_datasets(["app_messages"])
+///     .with_limit(3)
+///     .with_additional_columns(["timestamp"]);
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct SearchRequest {
+    /// The text to find similar documents for.
+    pub text: String,
+
+    /// Datasets to search. When empty, the runtime searches every searchable
+    /// dataset.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub datasets: Vec<String>,
+
+    /// Maximum matches to return per dataset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+
+    /// A SQL predicate filtering candidate rows, without the leading `WHERE` —
+    /// for example `"user_id = 42"`.
+    #[serde(rename = "where", skip_serializing_if = "Option::is_none")]
+    pub where_cond: Option<String>,
+
+    /// Extra columns to return with each match. A primary key column is
+    /// returned in [`SearchMatch::primary_key`], the rest in
+    /// [`SearchMatch::data`].
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub additional_columns: Vec<String>,
+
+    /// Keywords driving the lexical pass of a hybrid search.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub keywords: Vec<String>,
+}
+
+impl SearchRequest {
+    /// Creates a search for documents similar to `text`.
+    #[must_use]
+    pub fn new(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Restricts the search to the named datasets.
+    #[must_use]
+    pub fn with_datasets<I, S>(mut self, datasets: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.datasets = datasets.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Caps the number of matches returned per dataset.
+    #[must_use]
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Filters candidate rows with a SQL predicate, without the leading `WHERE`.
+    #[must_use]
+    pub fn with_where(mut self, where_cond: impl Into<String>) -> Self {
+        self.where_cond = Some(where_cond.into());
+        self
+    }
+
+    /// Returns extra columns alongside each match.
+    #[must_use]
+    pub fn with_additional_columns<I, S>(mut self, columns: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.additional_columns = columns.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Adds a lexical pass to the search, producing a hybrid ranking.
+    #[must_use]
+    pub fn with_keywords<I, S>(mut self, keywords: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.keywords = keywords.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Rejects requests the runtime would answer with a `400`, so the error
+    /// names the field to fix rather than reporting a status code.
+    pub(crate) fn validate(&self) -> Result<(), SearchError> {
+        if self.text.trim().is_empty() {
+            return Err(SearchError::InvalidRequest {
+                message: "text is required and must be a non-empty search string".to_string(),
+            });
+        }
+        if self.limit == Some(0) {
+            return Err(SearchError::InvalidRequest {
+                message: "limit must be greater than 0".to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// A single document matched by a search.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct SearchMatch {
+    /// The dataset the match was found in.
+    #[serde(default)]
+    pub dataset: String,
+
+    /// The match's similarity to the query. Higher is more similar.
+    #[serde(rename = "_score", default)]
+    pub score: f64,
+
+    /// The matched values, keyed by the column they came from. Each value is a
+    /// list because one column can contribute several chunks to a single match.
+    #[serde(default)]
+    pub matches: HashMap<String, Vec<serde_json::Value>>,
+
+    /// The primary key columns identifying the matched row. Empty when the
+    /// dataset declares no primary key.
+    #[serde(default)]
+    pub primary_key: HashMap<String, serde_json::Value>,
+
+    /// Any additional columns that were requested.
+    #[serde(default)]
+    pub data: HashMap<String, serde_json::Value>,
+
+    /// Extra per-match metadata the runtime attached.
+    #[serde(default)]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+/// The result of a single search.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct SearchResponse {
+    /// The matches, ordered by descending score.
+    #[serde(default)]
+    pub results: Vec<SearchMatch>,
+
+    /// How long the runtime reported the search took, in milliseconds.
+    #[serde(default)]
+    pub duration_ms: u128,
+}
+
+impl SearchResponse {
+    /// Returns the number of matches.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.results.len()
+    }
+
+    /// Returns true when the search found nothing.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.results.is_empty()
+    }
+}
+
+impl IntoIterator for SearchResponse {
+    type Item = SearchMatch;
+    type IntoIter = std::vec::IntoIter<SearchMatch>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.results.into_iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn body(request: &SearchRequest) -> serde_json::Value {
+        serde_json::to_value(request).expect("serialize search request")
+    }
+
+    #[test]
+    fn test_text_only_request_omits_optional_fields() {
+        assert_eq!(
+            body(&SearchRequest::new("tokyo")),
+            serde_json::json!({"text": "tokyo"})
+        );
+    }
+
+    #[test]
+    fn test_full_request_serialization() {
+        let request = SearchRequest::new("tokyo")
+            .with_datasets(["app_messages"])
+            .with_limit(3)
+            .with_where("user_id = 42")
+            .with_additional_columns(["timestamp"])
+            .with_keywords(["plane", "tickets"]);
+
+        assert_eq!(
+            body(&request),
+            serde_json::json!({
+                "text": "tokyo",
+                "datasets": ["app_messages"],
+                "limit": 3,
+                "where": "user_id = 42",
+                "additional_columns": ["timestamp"],
+                "keywords": ["plane", "tickets"],
+            })
+        );
+    }
+
+    #[test]
+    fn test_empty_datasets_omitted() {
+        // The runtime rejects an empty dataset list with a 400, so an empty
+        // vector must be omitted rather than sent.
+        let request = SearchRequest::new("tokyo").with_datasets(Vec::<String>::new());
+        assert_eq!(body(&request), serde_json::json!({"text": "tokyo"}));
+    }
+
+    #[test]
+    fn test_validate_rejects_empty_text() {
+        let err = SearchRequest::new("   ")
+            .validate()
+            .expect_err("empty text should be rejected");
+        assert!(err.to_string().contains("non-empty"), "{err}");
+    }
+
+    #[test]
+    fn test_validate_rejects_zero_limit() {
+        let err = SearchRequest::new("tokyo")
+            .with_limit(0)
+            .validate()
+            .expect_err("zero limit should be rejected");
+        assert!(err.to_string().contains("greater than 0"), "{err}");
+    }
+
+    #[test]
+    fn test_validate_accepts_minimal_request() {
+        SearchRequest::new("tokyo").validate().expect("valid");
+    }
+
+    #[test]
+    fn test_response_deserialization() {
+        let response: SearchResponse = serde_json::from_str(
+            r#"{
+                "results": [
+                    {
+                        "matches": {"message": ["I booked us some tickets", "direct to Narita"]},
+                        "dataset": "app_messages",
+                        "primary_key": {"id": "6fd5a215"},
+                        "data": {"timestamp": 1724716542},
+                        "metadata": {"chunk": 2},
+                        "_score": 0.914321
+                    },
+                    {
+                        "matches": {"message": ["we're sitting together"]},
+                        "dataset": "app_messages",
+                        "_score": 0.787654
+                    }
+                ],
+                "duration_ms": 42
+            }"#,
+        )
+        .expect("deserialize search response");
+
+        assert_eq!(response.duration_ms, 42);
+        assert_eq!(response.len(), 2);
+        assert!(!response.is_empty());
+
+        let first = &response.results[0];
+        assert_eq!(first.dataset, "app_messages");
+        assert!((first.score - 0.914_321).abs() < f64::EPSILON);
+        // One column can contribute several chunks to a single match.
+        assert_eq!(first.matches["message"].len(), 2);
+        assert_eq!(first.primary_key["id"], "6fd5a215");
+        assert_eq!(first.data["timestamp"], 1_724_716_542_i64);
+        assert_eq!(first.metadata["chunk"], 2);
+
+        // The runtime omits data, primary_key, and metadata when they are empty.
+        let second = &response.results[1];
+        assert!(second.primary_key.is_empty());
+        assert!(second.data.is_empty());
+        assert!(second.metadata.is_empty());
+    }
+
+    #[test]
+    fn test_empty_response() {
+        let response: SearchResponse =
+            serde_json::from_str(r#"{"results": [], "duration_ms": 3}"#).expect("deserialize");
+        assert!(response.is_empty());
+        assert_eq!(response.into_iter().count(), 0);
+    }
+}


### PR DESCRIPTION
## What

Adds `Client::search(SearchRequest)`, wrapping the runtime's `/v1/search` endpoint — vector similarity search, with optional keywords for a hybrid lexical + vector ranking.

```rust
let response = client
    .search(
        SearchRequest::new("tokyo plane tickets")
            .with_datasets(["app_messages"])
            .with_limit(3)
            .with_additional_columns(["timestamp"]),
    )
    .await?;

for m in response {
    println!("{} {} {:?}", m.score, m.dataset, m.matches);
}
```

## Why

`/v1/search` works on a default `spice run`, but of the six client SDKs only spice.js could reach it. Rust users had to hand-roll the HTTP call, including the response shape.

Part of aligning capabilities across the SDKs against the runtime's own API surface.

Shape follows what the crate already does: `SearchRequest` uses the `DatasetRefreshRequest` builder pattern (`mut self` -> `Self`, `#[must_use]`), `SearchError` is a typed `snafu` enum alongside `DatasetError` and `QueryError`, and the call goes through the existing `QueryHttpClient` so it picks up auth and the configured `http_url`.

Two details the response types encode, taken from the runtime's wire format rather than the OpenAPI example (which is out of date on the first point):

- `matches` holds a list of values per column — one column can contribute several chunks to a single match.
- `data`, `primary_key`, and `metadata` are omitted by the runtime when empty, so each defaults rather than being required.

Errors carry the runtime's plain-text explanation ("No data sources provided") next to the status code, which a status alone loses. Requests the runtime would reject with a 400 — empty text, a zero limit — are validated before sending so the error names the field to fix. An empty `datasets` vector is omitted rather than sent, since the runtime 400s on an empty list.

## Verification

- [x] `cargo build`
- [x] `cargo test --lib` — 199 passed, 0 failed (12 new: 8 unit in `search.rs`, 4 wiremock-backed in `client.rs`)
- [x] `cargo test --doc` — 28 passed, including the new README example
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --all-features --all-targets` — no new warnings. The two that remain are pre-existing: `QueryHttpClient::new` dead_code in the lib, and 5 `clone`/`from_ref` warnings in `tests/client_test.rs`.
- [ ] Integration tests — not run (no live runtime available)

## Review gate

Attests the trunk-merge conflict resolution in `e0d621d` (composition only — no behaviour change), not the original feature commits.

- Adversarial review: `codex` — scoped to `origin/trunk...HEAD` — verdict **needs-attention**, 4 findings, all against the pre-existing `search` surface rather than the merge resolution. Triaged and filed as #91 (an explicitly empty dataset scope fails open; defaults hide malformed responses; `cache_control` not forwarded; `with_keywords` documented as hybrid ranking but prefilters). Finding 1 is cheap now and breaking once released — see the PR comment.
- Conflict resolution verified lossless: `src/client.rs` function set is exactly the union of both sides (79 = 77 ∪ 74, no missing, no extra); diff vs `trunk` is 570 insertions and **0 deletions**, so nothing from #81 was dropped.
- Gate: `cargo fmt --all --check`, `cargo clippy --all-features`, `cargo test --lib` (223 passed), `cargo test --doc` (34 passed, including both recomposed README fences).