### PR TITLE
fix: keep the API key on the origin it was configured for

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -755,7 +755,9 @@ impl SpiceClientBuilder {
         let flight_channel = channel_builder.build().await?;
 
         let http_client = if let Some(url) = self.http_url {
-            let mut builder = reqwest::Client::builder();
+            // Built from the shared helper so the API key cannot follow a redirect off the
+            // origin it was configured for (#12502).
+            let mut builder = crate::redirect::credentialed_client_builder();
             if let (Some(cert_path), Some(key_path)) =
                 (&self.tls_client_certificate_file, &self.tls_client_key_file)
             {

--- a/src/client.rs
+++ b/src/client.rs
@@ -817,8 +817,10 @@ mod tests {
                 None,
                 MAX_RETRIES,
             )),
-            http_client: http_base_url
-                .map(|base_url| Arc::new(QueryHttpClient::new(base_url, None))),
+            http_client: http_base_url.map(|base_url| {
+                let client = QueryHttpClient::new(base_url, None);
+                Arc::new(client.expect("build client"))
+            }),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod dataset;
 mod flight;
 mod params;
 pub mod query;
+mod redirect;
 pub mod tls;
 mod util;
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -454,14 +454,19 @@ pub(crate) struct QueryHttpClient {
 }
 
 impl QueryHttpClient {
-    /// Builds a client carrying the same-origin redirect policy, so this constructor cannot
-    /// be the one path that leaks the API key across origins (#12502).
+    /// Builds a client carrying the same-origin redirect policy (#12502), for tests that need
+    /// one pointed at a mock server.
+    ///
+    /// Test-only: in production the sole construction path is [`Self::with_client`], fed by
+    /// `SpiceClientBuilder::build`. Keeping it that way is what makes the policy impossible to
+    /// miss, so this is gated rather than left as an unused second door into the type.
     ///
     /// # Errors
     ///
     /// Returns an error if the TLS backend cannot be initialised. The policy is the reason
     /// this is fallible where `reqwest::Client::new` — the call it replaces — panicked: a
     /// client built by defaulting past the failure would silently not carry it.
+    #[cfg(test)]
     pub fn new(base_url: &str, api_key: Option<String>) -> Result<Self, reqwest::Error> {
         let client = crate::redirect::credentialed_client_builder().build()?;
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -457,16 +457,15 @@ impl QueryHttpClient {
     /// Builds a client carrying the same-origin redirect policy, so this constructor cannot
     /// be the one path that leaks the API key across origins (#12502).
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the TLS backend cannot be initialised, which is what `reqwest::Client::new`
-    /// — the call this replaces — already did.
-    pub fn new(base_url: &str, api_key: Option<String>) -> Self {
-        let client = crate::redirect::credentialed_client_builder()
-            .build()
-            .expect("client builder should not fail");
+    /// Returns an error if the TLS backend cannot be initialised. The policy is the reason
+    /// this is fallible where `reqwest::Client::new` — the call it replaces — panicked: a
+    /// client built by defaulting past the failure would silently not carry it.
+    pub fn new(base_url: &str, api_key: Option<String>) -> Result<Self, reqwest::Error> {
+        let client = crate::redirect::credentialed_client_builder().build()?;
 
-        Self::with_client(client, base_url, api_key)
+        Ok(Self::with_client(client, base_url, api_key))
     }
 
     pub fn with_client(client: reqwest::Client, base_url: &str, api_key: Option<String>) -> Self {
@@ -1406,6 +1405,13 @@ mod tests {
     use futures::StreamExt;
 
     // -----------------------------------------------------------------------
+    // Helper: build a QueryHttpClient pointed at `base_url`
+    // -----------------------------------------------------------------------
+    fn test_http_client(base_url: &str) -> Arc<QueryHttpClient> {
+        Arc::new(QueryHttpClient::new(base_url, None).expect("build client"))
+    }
+
+    // -----------------------------------------------------------------------
     // Helper: build a ManifestSchemaColumn
     // -----------------------------------------------------------------------
     fn col(name: &str, type_name: &str, nullable: bool, position: usize) -> ManifestSchemaColumn {
@@ -1978,7 +1984,7 @@ mod tests {
     // -----------------------------------------------------------------------
     #[tokio::test]
     async fn test_empty_with_schema_yields_one_empty_batch() {
-        let client = Arc::new(QueryHttpClient::new("http://unused:9999", None));
+        let client = test_http_client("http://unused:9999");
         let schema = Arc::new(Schema::new(vec![
             Field::new("a", DataType::Int32, false),
             Field::new("b", DataType::Utf8, true),
@@ -2006,7 +2012,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_empty_with_schema_complex_types() {
-        let client = Arc::new(QueryHttpClient::new("http://unused:9999", None));
+        let client = test_http_client("http://unused:9999");
         let schema = Arc::new(Schema::new(vec![
             Field::new(
                 "ts",
@@ -2034,7 +2040,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_empty_with_schema_no_columns() {
-        let client = Arc::new(QueryHttpClient::new("http://unused:9999", None));
+        let client = test_http_client("http://unused:9999");
         let schema = Arc::new(Schema::empty());
         let mut stream = QueryResultStream::empty_with_schema(
             client,
@@ -2079,7 +2085,7 @@ mod tests {
         let meta: ManifestMetadata = serde_json::from_value(json).expect("should deserialize");
         let schema = schema_from_manifest(meta.schema.as_ref().expect("schema present"));
 
-        let client = Arc::new(QueryHttpClient::new("http://unused:9999", None));
+        let client = test_http_client("http://unused:9999");
         let mut stream =
             QueryResultStream::empty_with_schema(client, "e2e-query".to_string(), schema);
 
@@ -2133,7 +2139,7 @@ mod tests {
         let meta: ManifestMetadata = serde_json::from_value(json).expect("should deserialize");
         let schema = schema_from_manifest(meta.schema.as_ref().expect("schema present"));
 
-        let client = Arc::new(QueryHttpClient::new("http://unused:9999", None));
+        let client = test_http_client("http://unused:9999");
         let mut stream =
             QueryResultStream::empty_with_schema(client, "all-nullable".to_string(), schema);
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -454,8 +454,19 @@ pub(crate) struct QueryHttpClient {
 }
 
 impl QueryHttpClient {
+    /// Builds a client carrying the same-origin redirect policy, so this constructor cannot
+    /// be the one path that leaks the API key across origins (#12502).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the TLS backend cannot be initialised, which is what `reqwest::Client::new`
+    /// — the call this replaces — already did.
     pub fn new(base_url: &str, api_key: Option<String>) -> Self {
-        Self::with_client(reqwest::Client::new(), base_url, api_key)
+        let client = crate::redirect::credentialed_client_builder()
+            .build()
+            .expect("client builder should not fail");
+
+        Self::with_client(client, base_url, api_key)
     }
 
     pub fn with_client(client: reqwest::Client, base_url: &str, api_key: Option<String>) -> Self {

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -34,11 +34,11 @@ fn is_same_origin(previous: &reqwest::Url, next: &reqwest::Url) -> bool {
 fn same_origin_redirect_policy() -> reqwest::redirect::Policy {
     reqwest::redirect::Policy::custom(|attempt| {
         // Decided up front so every borrow of `attempt` ends before it is consumed below.
-        let leaves_origin = match attempt.previous().last() {
-            // Nothing to compare against, so nothing proves this stays on origin.
-            None => true,
-            Some(previous) => !is_same_origin(previous, attempt.url()),
-        };
+        // No previous hop means nothing proves this stays on origin, hence `is_none_or`.
+        let leaves_origin = attempt
+            .previous()
+            .last()
+            .is_none_or(|previous| !is_same_origin(previous, attempt.url()));
         let too_many_hops = attempt.previous().len() > MAX_REDIRECTS;
 
         if leaves_origin || too_many_hops {
@@ -53,6 +53,7 @@ fn same_origin_redirect_policy() -> reqwest::redirect::Policy {
 ///
 /// Every HTTP client in this crate is built from here, so the policy cannot be set on one
 /// construction path and missed on another.
+#[must_use]
 pub(crate) fn credentialed_client_builder() -> reqwest::ClientBuilder {
     let policy = same_origin_redirect_policy();
     reqwest::Client::builder().redirect(policy)

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -1,0 +1,114 @@
+//! Redirect handling for the credential-bearing HTTP client.
+//!
+//! The async query API attaches the API key as an `X-API-Key` header. When a redirect leaves
+//! the origin, `reqwest` strips only the standard credential headers — `Authorization`,
+//! `Cookie`, `cookie2`, `Proxy-Authorization` and `WWW-Authenticate` — so a custom header such
+//! as `X-API-Key` rides along to whatever the `Location` names. A runtime, proxy or ingress
+//! answering with an off-origin `Location` would therefore be handed the key.
+//!
+//! See <https://github.com/spiceai/spiceai/issues/12502>.
+
+/// How many same-origin redirects to follow before giving up.
+///
+/// `reqwest::redirect::Policy::custom` does not apply the default hop limit — its own docs
+/// note the closure has to handle loops itself — so the bound is enforced here. It is
+/// compared the way `Policy::limited` compares it: `previous()` includes the originating URL,
+/// so the bound is exclusive and this matches `reqwest`'s default depth.
+const MAX_REDIRECTS: usize = 10;
+
+/// Whether two URLs share an origin: scheme, host and effective port.
+///
+/// `port_or_known_default` is what makes `http://host` and `http://host:80` one origin; `Url`
+/// has already lowercased the host by the time it gets here.
+fn is_same_origin(previous: &reqwest::Url, next: &reqwest::Url) -> bool {
+    previous.scheme() == next.scheme()
+        && previous.host_str() == next.host_str()
+        && previous.port_or_known_default() == next.port_or_known_default()
+}
+
+/// A redirect policy that follows same-origin redirects and refuses to leave the origin.
+///
+/// Stopping rather than erroring hands the 3xx back as a response, which the callers in
+/// [`crate::query`] already report with its status code, so a refused redirect stays a
+/// diagnosable condition instead of an opaque transport failure.
+fn same_origin_redirect_policy() -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(|attempt| {
+        // Decided up front so every borrow of `attempt` ends before it is consumed below.
+        let leaves_origin = match attempt.previous().last() {
+            // Nothing to compare against, so nothing proves this stays on origin.
+            None => true,
+            Some(previous) => !is_same_origin(previous, attempt.url()),
+        };
+        let too_many_hops = attempt.previous().len() > MAX_REDIRECTS;
+
+        if leaves_origin || too_many_hops {
+            return attempt.stop();
+        }
+
+        attempt.follow()
+    })
+}
+
+/// A `reqwest` client builder that will not carry a credential off its origin.
+///
+/// Every HTTP client in this crate is built from here, so the policy cannot be set on one
+/// construction path and missed on another.
+pub(crate) fn credentialed_client_builder() -> reqwest::ClientBuilder {
+    let policy = same_origin_redirect_policy();
+    reqwest::Client::builder().redirect(policy)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn url(value: &str) -> reqwest::Url {
+        reqwest::Url::parse(value).expect("test URL should parse")
+    }
+
+    #[test]
+    fn test_is_same_origin_matches_scheme_host_and_effective_port() {
+        let base = url("http://host:8090/v1/queries");
+        let sibling = url("http://host:8090/v1/queries/1");
+        assert!(is_same_origin(&base, &sibling));
+
+        // An implicit default port is the same origin as the explicit one.
+        let implicit_http = url("http://host/a");
+        let explicit_http = url("http://host:80/b");
+        assert!(is_same_origin(&implicit_http, &explicit_http));
+
+        let implicit_https = url("https://host/a");
+        let explicit_https = url("https://host:443/b");
+        assert!(is_same_origin(&implicit_https, &explicit_https));
+    }
+
+    #[test]
+    fn test_is_same_origin_rejects_a_different_origin() {
+        let base = url("https://runtime.example.com/v1/queries");
+
+        // A different host is a different origin.
+        let other_host = url("https://attacker.example.com/v1/queries");
+        assert!(!is_same_origin(&base, &other_host));
+
+        // So is a different port on the same host.
+        let other_port = url("https://runtime.example.com:8443/v1/queries");
+        assert!(!is_same_origin(&base, &other_port));
+    }
+
+    /// The case `reqwest`'s own stripping would miss: it compares host and effective port but
+    /// never scheme, so a downgrade that keeps the port is not "cross-host" to it — and a
+    /// plaintext hop is exactly where a credential must not go.
+    #[test]
+    fn test_is_same_origin_rejects_a_scheme_downgrade_on_the_same_port() {
+        let secure = url("https://runtime.example.com:8443/v1/queries");
+        let plaintext = url("http://runtime.example.com:8443/v1/queries");
+        assert!(!is_same_origin(&secure, &plaintext));
+    }
+
+    #[test]
+    fn test_is_same_origin_ignores_path_query_and_fragment() {
+        let with_query = url("http://host:8090/v1/queries?a=1#x");
+        let other_path = url("http://host:8090/other?b=2#y");
+        assert!(is_same_origin(&with_query, &other_path));
+    }
+}

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -53,7 +53,6 @@ fn same_origin_redirect_policy() -> reqwest::redirect::Policy {
 ///
 /// Every HTTP client in this crate is built from here, so the policy cannot be set on one
 /// construction path and missed on another.
-#[must_use]
 pub(crate) fn credentialed_client_builder() -> reqwest::ClientBuilder {
     let policy = same_origin_redirect_policy();
     reqwest::Client::builder().redirect(policy)

--- a/tests/redirect_test.rs
+++ b/tests/redirect_test.rs
@@ -1,0 +1,121 @@
+//! The API key must not follow a redirect off the origin it was configured for.
+//!
+//! Regression test for <https://github.com/spiceai/spiceai/issues/12502>. The SDK sends the key
+//! in an `X-API-Key` header, and `reqwest` strips only the standard credential headers on a
+//! cross-origin hop, so before the same-origin redirect policy a 307 would have replayed the
+//! POST — header and body alike — to whatever origin the `Location` named.
+
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const API_KEY: &str = "test-api-key-must-not-leak";
+
+/// Building a client needs a Flight endpoint, but the channel connects lazily and these tests
+/// only exercise the HTTP path, so nothing ever dials it.
+const UNUSED_FLIGHT_URL: &str = "http://127.0.0.1:1";
+
+fn submit_response() -> serde_json::Value {
+    json!({
+        "query_id": "query-1",
+        "status": "PENDING",
+        "status_url": "/v1/queries/query-1/status",
+        "results_url": "/v1/queries/query-1/results"
+    })
+}
+
+/// A 307, which preserves the method and the body, so the credentialed POST would be replayed
+/// verbatim to `url` if the policy let the hop through.
+fn redirect_to(url: &str) -> ResponseTemplate {
+    ResponseTemplate::new(307).insert_header("location", url)
+}
+
+fn accepted() -> ResponseTemplate {
+    ResponseTemplate::new(202).set_body_json(submit_response())
+}
+
+async fn client_for(http_url: &str) -> spiceai::Client {
+    spiceai::ClientBuilder::new()
+        .http_url(http_url)
+        .api_key(API_KEY)
+        .flight_url(UNUSED_FLIGHT_URL)
+        .build()
+        .await
+        .expect("client should build")
+}
+
+#[tokio::test]
+async fn test_cross_origin_redirect_does_not_carry_the_api_key() {
+    // A second origin, which would receive the replayed POST if the redirect were followed.
+    let other_origin = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/queries"))
+        .respond_with(accepted())
+        .mount(&other_origin)
+        .await;
+
+    let runtime = MockServer::start().await;
+    let off_origin = format!("{}/v1/queries", other_origin.uri());
+    Mock::given(method("POST"))
+        .and(path("/v1/queries"))
+        .respond_with(redirect_to(&off_origin))
+        .mount(&runtime)
+        .await;
+
+    let client = client_for(&runtime.uri()).await;
+    let error = client
+        .query("SELECT 1")
+        .await
+        .expect_err("a refused redirect should not submit a query");
+
+    // Stopping hands the 3xx back as a response, so it surfaces with its status code rather
+    // than as an opaque transport failure.
+    assert!(
+        error.to_string().contains("307"),
+        "expected the refused redirect to surface as HTTP 307, got: {error}"
+    );
+
+    // The point of the fix: the off-origin server was never contacted, so it never saw the key.
+    let received = other_origin
+        .received_requests()
+        .await
+        .expect("the mock server records requests");
+    assert!(
+        received.is_empty(),
+        "the API key left its origin: the off-origin server received {} request(s)",
+        received.len()
+    );
+}
+
+#[tokio::test]
+async fn test_same_origin_redirect_is_still_followed() {
+    let runtime = MockServer::start().await;
+    let relocated = "/v1/queries-relocated";
+    let same_origin = format!("{}{relocated}", runtime.uri());
+
+    Mock::given(method("POST"))
+        .and(path("/v1/queries"))
+        .respond_with(redirect_to(&same_origin))
+        .mount(&runtime)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(relocated))
+        .respond_with(accepted())
+        .mount(&runtime)
+        .await;
+
+    let client = client_for(&runtime.uri()).await;
+    let job = client
+        .query("SELECT 1")
+        .await
+        .expect("a same-origin redirect should still be followed");
+
+    assert_eq!(job.id(), "query-1");
+
+    // Both hops landed on the runtime: the original path and the relocated one.
+    let received = runtime
+        .received_requests()
+        .await
+        .expect("the mock server records requests");
+    assert_eq!(received.len(), 2);
+}


### PR DESCRIPTION
## Summary

The async query client attaches the API key as an `X-API-Key` header. On a redirect that leaves the origin, `reqwest` strips only the standard credential headers, so a custom header rides along to whatever the `Location` names — and a 307/308 preserves the method and the body, so the entire credentialed POST is replayed to the new origin.

Verified against the pinned major rather than assumed. `reqwest` v0.12.24, `src/redirect.rs`:

```rust
let cross_host = next.host_str() != previous.host_str()
    || next.port_or_known_default() != previous.port_or_known_default();
if cross_host {
    headers.remove(AUTHORIZATION);
    headers.remove(COOKIE);
    headers.remove("cookie2");
    headers.remove(PROXY_AUTHORIZATION);
    headers.remove(WWW_AUTHENTICATE);
}
```

`X-API-Key` is not in that set, so nothing stripped it. This is the SDK half of spiceai/spiceai#12502: the CLI set a same-origin policy on its own client for spiceai/spiceai#12495, but `spice query` and `spice nsql analyze` build *this* crate's client instead, and the policy cannot be set from the CLI — the SDK pins `reqwest` 0.12 while the workspace is on 0.13, so the two `Client` types are not interchangeable and `ClientBuilder` exposes no redirect setter. The crate that attaches the credential is the one that has to own the policy.

## Changes

- **New `src/redirect.rs`** — `credentialed_client_builder()`, a `reqwest::ClientBuilder` carrying a same-origin redirect policy.
- **Applied at both construction sites** — `SpiceClientBuilder::build` (the production path) and `QueryHttpClient::new`. Both now come from the one helper, so the policy cannot be set on one path and missed on another.

### Design notes worth a reviewer's eye

**The hop limit is enforced by hand, on purpose.** `Policy::custom` does *not* inherit the default limit — reqwest's own docs say "The default `Policy` handles a maximum loop chain, but the custom variant does not do that for you automatically." Dropping it would have turned a same-origin redirect loop into an infinite one, so the policy applies the bound itself, compared the way `Policy::limited` compares it (`previous()` includes the originating URL, so the bound is exclusive).

**Origin means scheme, host and effective port** — deliberately stricter than the `cross_host` check quoted above, which never looks at scheme. An `https://host:8443` → `http://host:8443` downgrade keeps the host and port identical, so reqwest would not call it cross-host, but it is exactly where a credential must not go. There is a test for that specific case.

**It stops rather than errors.** The callers in `query.rs` already report an unexpected status with its code, so a refused redirect surfaces as `Failed to submit query (HTTP 307)` instead of an opaque transport error.

**Secure by default, with no opt-out.** This is a behaviour change: a deployment that today relies on the SDK following an off-origin redirect will now get a 307 back instead. That configuration is precisely the one leaking the key, so it fails closed rather than continuing to disclose the credential — and it matches the choice already made for the CLI client in spiceai/spiceai#12495.

## Test plan

`cargo fmt --all --check`, `cargo clippy --all-features` and `cargo test` (what CI runs).

- `tests/redirect_test.rs::test_cross_origin_redirect_does_not_carry_the_api_key` — the regression test, driven through the public production path (`ClientBuilder::build`). Two mock servers: the runtime answers the credentialed POST with a 307 pointing at a second origin, which is mounted to accept it. Asserts the second origin received **zero** requests, and that the refused hop surfaces as HTTP 307. On the old code the redirect is followed and the off-origin server receives the POST with `X-API-Key`, so this fails without the fix.
- `tests/redirect_test.rs::test_same_origin_redirect_is_still_followed` — guards against over-correcting: a 307 to a different path on the *same* origin is still followed, the body is replayed, and the submit succeeds.
- `src/redirect.rs` unit tests — origin equality across implicit/explicit default ports, differing host, differing port, scheme downgrade on an identical port, and path/query/fragment being irrelevant.

## Notes

I could not build or run these locally (no Rust toolchain on the machine that wrote the patch), so CI is the first real execution — every external API used here was instead checked against the pinned sources: `reqwest` v0.12.24 for `Attempt`/`Policy`/`Action::Stop` semantics, and `wiremock` v0.6.5 for `insert_header`, `set_body_json` and `received_requests`. Flagging it rather than implying a green local run. The adversarial review pass I would normally run on the diff could not execute either (the review engine's workspace is out of credits).

Follow-up, not in this PR: once this lands and the `spiceai` rev is bumped in spiceai/spiceai, `spice query` and `spice nsql analyze` inherit the policy and spiceai/spiceai#12502 can close. Whether the CLI should build SDK clients per command at all — versus routing both through the shared context client — is the broader question that issue also raises, and is left open.

Refs: https://github.com/spiceai/spiceai/issues/12502
