### PR TITLE
fix(test): skip the cloud tests without a credential instead of failing

### DIFF
--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -59,7 +59,7 @@ mod tests {
                 Some(spice_client) => spice_client,
                 None => {
                     eprintln!(
-                        "skipping cloud test: SCP_SPICEAI_TPCH_API_KEY is unset or empty (expected on a fork pull request)"
+                        "skipping cloud test: SCP_SPICEAI_TPCH_API_KEY is unset or empty - set it to run the cloud tests. Expected on a fork pull request, which cannot read repository secrets, and on a local run without the variable exported; on a branch that can read secrets, it means the secret is missing or misconfigured."
                     );
                     return;
                 }

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -14,21 +14,62 @@ mod tests {
     use std::path::Path;
     use std::sync::Arc;
 
-    async fn new_cloud_client() -> Client {
+    /// The Spice.ai Cloud API key the cloud tests query with, or `None` when no
+    /// credential is available.
+    ///
+    /// An empty value counts as absent: `build.yml` passes the key as
+    /// `SCP_SPICEAI_TPCH_API_KEY: ${{ secrets.SCP_SPICEAI_TPCH_API_KEY }}`, and a
+    /// workflow run that cannot read repository secrets — every pull request from a
+    /// fork — renders that expression as the empty string rather than leaving the
+    /// variable unset. Checking only `env::var` would therefore never see the
+    /// credential as missing on the runs that actually lack it.
+    fn cloud_api_key() -> Option<String> {
         dotenv::from_path(Path::new(".env.local")).ok();
-        let api_key =
-            env::var("SCP_SPICEAI_TPCH_API_KEY").expect("SCP_SPICEAI_TPCH_API_KEY not found");
-        ClientBuilder::new()
-            .api_key(&api_key)
-            .use_spiceai_cloud()
-            .build()
-            .await
-            .expect("Failed to create client")
+        match env::var("SCP_SPICEAI_TPCH_API_KEY") {
+            Ok(api_key) if !api_key.trim().is_empty() => Some(api_key),
+            _ => None,
+        }
+    }
+
+    async fn new_cloud_client() -> Option<Client> {
+        let api_key = cloud_api_key()?;
+        Some(
+            ClientBuilder::new()
+                .api_key(&api_key)
+                .use_spiceai_cloud()
+                .build()
+                .await
+                .expect("Failed to create client"),
+        )
+    }
+
+    /// Yields a cloud client, or returns from the calling test when no credential is
+    /// available.
+    ///
+    /// Rust's test harness has no runtime `skip`, so a credential-less run reports
+    /// these tests as *passing* rather than skipped. That silent pass is the
+    /// deliberate trade-off: without it, a fork pull request fails all ten
+    /// `Build and test` legs on a missing secret it can never be given, which hides
+    /// whether the change under review is actually sound. The tests still run for
+    /// real on every branch that can read the secret, which is where a regression in
+    /// the cloud paths has to be caught.
+    macro_rules! cloud_client_or_skip {
+        () => {
+            match new_cloud_client().await {
+                Some(spice_client) => spice_client,
+                None => {
+                    eprintln!(
+                        "skipping cloud test: SCP_SPICEAI_TPCH_API_KEY is unset or empty (expected on a fork pull request)"
+                    );
+                    return;
+                }
+            }
+        };
     }
 
     #[tokio::test]
     async fn test_new_client_builder() {
-        new_cloud_client().await;
+        let _spice_client = cloud_client_or_skip!();
     }
 
     async fn new_local_client() -> Client {
@@ -388,7 +429,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_query() {
-        let spice_client = new_cloud_client().await;
+        let spice_client = cloud_client_or_skip!();
         match spice_client
             .sql("select c_custkey, c_name, c_nationkey from tpch.customer limit 10;")
             .await
@@ -419,7 +460,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_query_streaming() {
-        let spice_client = new_cloud_client().await;
+        let spice_client = cloud_client_or_skip!();
         match spice_client
             .sql("select l_orderkey, l_partkey, l_quantity from tpch.lineitem limit 10000")
             .await
@@ -451,7 +492,7 @@ mod tests {
     /// Test querying integer and string types from the nation table
     #[tokio::test]
     async fn test_tpch_nation_types() {
-        let spice_client = new_cloud_client().await;
+        let spice_client = cloud_client_or_skip!();
         match spice_client
             .sql("SELECT n_nationkey, n_name, n_regionkey, n_comment FROM tpch.nation ORDER BY n_nationkey LIMIT 5")
             .await
@@ -477,7 +518,7 @@ mod tests {
     /// Test querying decimal types from the orders table
     #[tokio::test]
     async fn test_tpch_orders_decimal_types() {
-        let spice_client = new_cloud_client().await;
+        let spice_client = cloud_client_or_skip!();
         match spice_client
             .sql("SELECT o_orderkey, o_custkey, o_totalprice, o_orderstatus FROM tpch.orders ORDER BY o_orderkey LIMIT 10")
             .await
@@ -503,7 +544,7 @@ mod tests {
     /// Test querying date types from the orders table
     #[tokio::test]
     async fn test_tpch_orders_date_types() {
-        let spice_client = new_cloud_client().await;
+        let spice_client = cloud_client_or_skip!();
         match spice_client
             .sql("SELECT o_orderkey, o_orderdate, o_orderpriority FROM tpch.orders ORDER BY o_orderdate LIMIT 10")
             .await
@@ -529,7 +570,7 @@ mod tests {
     /// Test querying multiple decimal columns from the lineitem table
     #[tokio::test]
     async fn test_tpch_lineitem_decimal_types() {
-        let spice_client = new_cloud_client().await;
+        let spice_client = cloud_client_or_skip!();
         match spice_client
             .sql("SELECT l_orderkey, l_quantity, l_extendedprice, l_discount, l_tax FROM tpch.lineitem LIMIT 20")
             .await
@@ -555,7 +596,7 @@ mod tests {
     /// Test querying multiple date columns from the lineitem table
     #[tokio::test]
     async fn test_tpch_lineitem_date_types() {
-        let spice_client = new_cloud_client().await;
+        let spice_client = cloud_client_or_skip!();
         match spice_client
             .sql(
                 "SELECT l_orderkey, l_shipdate, l_commitdate, l_receiptdate FROM tpch.lineitem LIMIT 15",
@@ -583,7 +624,7 @@ mod tests {
     /// Test aggregation query with GROUP BY
     #[tokio::test]
     async fn test_tpch_aggregation() {
-        let spice_client = new_cloud_client().await;
+        let spice_client = cloud_client_or_skip!();
         match spice_client
             .sql("SELECT n_regionkey, COUNT(*) as nation_count FROM tpch.nation GROUP BY n_regionkey ORDER BY n_regionkey")
             .await
@@ -609,7 +650,7 @@ mod tests {
     /// Test query with SUM aggregation on decimal columns
     #[tokio::test]
     async fn test_tpch_sum_aggregation() {
-        let spice_client = new_cloud_client().await;
+        let spice_client = cloud_client_or_skip!();
         match spice_client
             .sql("SELECT o_orderstatus, COUNT(*) as order_count, SUM(o_totalprice) as total_value FROM tpch.orders GROUP BY o_orderstatus ORDER BY o_orderstatus")
             .await
@@ -635,7 +676,7 @@ mod tests {
     /// Test query with JOIN between tables
     #[tokio::test]
     async fn test_tpch_join_query() {
-        let spice_client = new_cloud_client().await;
+        let spice_client = cloud_client_or_skip!();
         match spice_client
             .sql("SELECT n.n_name, r.r_name FROM tpch.nation n JOIN tpch.region r ON n.n_regionkey = r.r_regionkey ORDER BY n.n_name LIMIT 10")
             .await
@@ -660,7 +701,7 @@ mod tests {
     /// Test querying the region table (small reference table)
     #[tokio::test]
     async fn test_tpch_region_table() {
-        let spice_client = new_cloud_client().await;
+        let spice_client = cloud_client_or_skip!();
         match spice_client
             .sql("SELECT r_regionkey, r_name, r_comment FROM tpch.region ORDER BY r_regionkey")
             .await
@@ -686,7 +727,7 @@ mod tests {
     /// Test querying the supplier table with decimal (acctbal) type
     #[tokio::test]
     async fn test_tpch_supplier_types() {
-        let spice_client = new_cloud_client().await;
+        let spice_client = cloud_client_or_skip!();
         match spice_client
             .sql("SELECT s_suppkey, s_name, s_acctbal, s_nationkey FROM tpch.supplier ORDER BY s_suppkey LIMIT 10")
             .await
@@ -712,7 +753,7 @@ mod tests {
     /// Test querying the part table with various types
     #[tokio::test]
     async fn test_tpch_part_types() {
-        let spice_client = new_cloud_client().await;
+        let spice_client = cloud_client_or_skip!();
         match spice_client
             .sql("SELECT p_partkey, p_name, p_brand, p_size, p_retailprice FROM tpch.part ORDER BY p_partkey LIMIT 10")
             .await
@@ -738,7 +779,7 @@ mod tests {
     /// Test querying the partsupp table
     #[tokio::test]
     async fn test_tpch_partsupp_types() {
-        let spice_client = new_cloud_client().await;
+        let spice_client = cloud_client_or_skip!();
         match spice_client
             .sql(
                 "SELECT ps_partkey, ps_suppkey, ps_availqty, ps_supplycost FROM tpch.partsupp LIMIT 10",
@@ -766,7 +807,7 @@ mod tests {
     /// Test query with calculated/derived columns
     #[tokio::test]
     async fn test_tpch_calculated_columns() {
-        let spice_client = new_cloud_client().await;
+        let spice_client = cloud_client_or_skip!();
         match spice_client
             .sql("SELECT l_orderkey, l_quantity, l_extendedprice, l_discount, l_extendedprice * (1 - l_discount) as net_price FROM tpch.lineitem LIMIT 10")
             .await
@@ -791,7 +832,7 @@ mod tests {
     /// Test query with WHERE clause filtering
     #[tokio::test]
     async fn test_tpch_filtered_query() {
-        let spice_client = new_cloud_client().await;
+        let spice_client = cloud_client_or_skip!();
         match spice_client
             .sql("SELECT c_custkey, c_name, c_acctbal FROM tpch.customer WHERE c_acctbal > 0 ORDER BY c_acctbal DESC LIMIT 10")
             .await


### PR DESCRIPTION
## What was wrong

`build.yml` hands the Spice.ai Cloud credential to `cargo test` as:

```yaml
env:
  SCP_SPICEAI_TPCH_API_KEY: ${{ secrets.SCP_SPICEAI_TPCH_API_KEY }}
```

A workflow run that cannot read repository secrets — **every pull request from a fork** — renders that expression as the **empty string** rather than leaving the variable unset. So `env::var` succeeds, `.expect("SCP_SPICEAI_TPCH_API_KEY not found")` never fires, and an empty key travels to the server. All 16 cloud tests then panic at handshake:

```
Error: Query execution failed: Ipc error: Can't handshake
code: 'The request does not have valid authentication credentials', message: "API key is required"
```

That fails all **ten** `Build and test` legs over a credential the run can never be given, which hides whether the change under review is actually sound. It is currently the only thing blocking #81 (approved) and #84.

Because the variable is present-but-empty, a guard that checked only whether `env::var` returned an error would never see the credential as missing on the runs that actually lack it — so this treats empty as absent.

## What this does

- `cloud_api_key() -> Option<String>` — reads the key, treating unset **and** empty/whitespace as absent. The value returned is untrimmed, so a real key is passed through byte-identically.
- `new_cloud_client() -> Option<Client>`.
- `cloud_client_or_skip!()` — yields the client, or prints the reason to stderr and returns from the test. Used at all 17 cloud call sites.

Scope is `tests/client_test.rs` only; no `src/` or workflow change.

## The trade-off, named

Rust's test harness has no runtime `skip`, so a credential-less run reports these tests as **passing** rather than skipped. That silent pass is deliberate, and bounded:

- Only runs without the secret are affected — i.e. fork pull requests. Every branch in this repo, and `trunk`, still runs all 16 cloud tests for real against the live service.
- The 196 unit tests and the 8 local-runtime tests already pass on forks and are untouched, so a fork PR keeps meaningful signal instead of an all-red matrix.
- The empty-key *builder* path stays covered on forks by the existing unit test `client::tests::test_client_builder_empty_api_key`.

Gating the whole test step in the workflow instead was considered and rejected: unit and integration tests share one `cargo test` invocation, so it would also have dropped the 8 local tests that forks *can* run for real.

## Verification

Both directions, locally:

| `SCP_SPICEAI_TPCH_API_KEY` | Result |
|---|---|
| empty (the fork case) | `16 passed; 0 failed` — was 16 failed |
| unset | skips, with `skipping cloud test: … is unset or empty (expected on a fork pull request)` on stderr |
| set to a dummy non-empty value | tests **still run**: reach the server and fail `message: "invalid API key"` |

The third row is the load-bearing one: the message changes from `"API key is required"` (empty) to `"invalid API key"` (dummy), which is server-side proof the key was actually transmitted — the guard does not disable these tests whenever a credential exists.

`cargo fmt --all` clean. `cargo clippy --all-features` (CI's scope) clean; the 5 pre-existing `cloned_ref_to_slice_refs` findings under `--all-targets` reproduce unchanged at the `trunk` baseline and are left alone as out of scope.
