### PR TITLE
feat: add active_queries and cancel_active_query for running SQL queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
 ### List and cancel running queries
 
-`active_queries()` reports the synchronous queries this client currently has running — the ones started by `sql()`, FlightSQL, `/v1/sql`, NSQL, and search — and `cancel_active_query()` stops one by id.
+`active_queries()` reports the synchronous queries currently running in the caller's scope — the ones started by `sql()`, FlightSQL, `/v1/sql`, NSQL, and search — and `cancel_active_query()` stops one by id.
 
-The runtime does not hand a query's id back to the client that submitted it, so the two are used together: list to find the query, then cancel it. Both are scoped to the caller, so a client only ever sees and cancels its own queries.
+The runtime does not hand a query's id back to the client that submitted it, so the two are used together: list to find the query, then cancel it.
+
+Two boundaries apply, and a query is reachable only inside both.
+
+**One runtime instance.** The runtime tracks active synchronous queries in memory, per instance, and these endpoints report only what the instance answering them knows. A `Client` configures its Flight and HTTP endpoints independently, so behind a load balancer the query submitted over Flight may be running on a different instance than the one answering here — it will not be listed, and its id reports as not found. Point `http_url()` at the instance running the query.
+
+**One authenticated principal**, not a `Client` instance. The principal is whatever credential the runtime authenticates — an API key or a client certificate — so every client presenting the same credential lists and cancels the same queries. Only requests for which the runtime establishes no principal at all share the `public` scope. A query outside the caller's scope is reported as if it did not exist.
+
+> **Runtime version.** Principal scoping on these two endpoints landed in [spiceai/spiceai#12841](https://github.com/spiceai/spiceai/pull/12841) and is in no runtime release up to and including `v2.1.5`. Against an earlier runtime both calls operate on every active query the instance holds, for any caller with write access. Check your runtime version before relying on the scope described above.
 
 ```rust,no_run
 use spiceai::ClientBuilder;

--- a/README.md
+++ b/README.md
@@ -168,6 +168,40 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 }
 ```
 
+### List and cancel running queries
+
+`active_queries()` reports the synchronous queries this client currently has running — the ones started by `sql()`, FlightSQL, `/v1/sql`, NSQL, and search — and `cancel_active_query()` stops one by id.
+
+The runtime does not hand a query's id back to the client that submitted it, so the two are used together: list to find the query, then cancel it. Both are scoped to the caller, so a client only ever sees and cancels its own queries.
+
+```rust,no_run
+use spiceai::ClientBuilder;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+  let client = ClientBuilder::new()
+    .http_url("http://localhost:8090")
+    .build()
+    .await?;
+
+  let active = client.active_queries().await?;
+  println!("{} queries running", active.total_count);
+
+  for query in &active.queries {
+    println!("{} [{}] {}", query.query_id, query.protocol, query.sql_preview);
+  }
+
+  if let Some(query) = active.queries.first() {
+    let cancelled = client.cancel_active_query(&query.query_id).await?;
+    println!("{} is now {}", cancelled.query_id, cancelled.status);
+  }
+
+  Ok(())
+}
+```
+
+To cancel an *async query job* instead, use `cancel_query()` — see [Async query jobs](#async-query-jobs-and-dataset-refresh) above.
+
 ## Documentation
 
 Check out our [Documentation](https://docs.spice.ai/sdks/rust-sdk) to learn more about how to use the Rust SDK.

--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -1,0 +1,180 @@
+//! Listing and cancelling *synchronous* queries running on the runtime.
+//!
+//! This is distinct from the async query jobs in [`crate::query`]. A synchronous
+//! query is one started by [`Client::sql()`](crate::Client::sql), FlightSQL,
+//! `/v1/sql`, NSQL, or `/v1/search` — it streams results back on the connection
+//! that started it. Async jobs are submitted with
+//! [`Client::query()`](crate::Client::query), are polled for completion, and
+//! require the runtime to be running in cluster mode.
+//!
+//! The runtime assigns a `query_id` to every synchronous query but does not
+//! return it to the client that submitted it, so the two operations here are
+//! used together: list the active queries to find the one you want, then cancel
+//! it by id. Listing and cancellation are both scoped to the caller, so a client
+//! only ever sees and cancels its own queries.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use spiceai::ClientBuilder;
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+//!     let client = ClientBuilder::new()
+//!         .http_url("http://localhost:8090")
+//!         .build()
+//!         .await?;
+//!
+//!     let active = client.active_queries().await?;
+//!     for query in &active.queries {
+//!         println!("{} [{}] {}", query.query_id, query.protocol, query.sql_preview);
+//!     }
+//!
+//!     if let Some(query) = active.queries.first() {
+//!         client.cancel_active_query(&query.query_id).await?;
+//!     }
+//!
+//!     Ok(())
+//! }
+//! ```
+
+use serde::Deserialize;
+use snafu::Snafu;
+
+/// Errors that can occur while listing or cancelling active synchronous queries.
+#[derive(Debug, Snafu)]
+pub enum ActiveQueryError {
+    /// No active synchronous query with this id belongs to the caller.
+    ///
+    /// The runtime reports a query submitted by another caller the same way it
+    /// reports one that does not exist, so a client cannot probe for other
+    /// callers' query ids.
+    #[snafu(display(
+        "No active query '{query_id}' found. It may have already finished, or it was submitted by a different client."
+    ))]
+    NotFound { query_id: String },
+
+    /// The supplied id is not a UUID, so it cannot name a query.
+    #[snafu(display(
+        "Query id '{query_id}' is not a valid UUID. Use the query_id from active_queries()."
+    ))]
+    InvalidQueryId { query_id: String },
+
+    /// The configured API key does not grant write access.
+    #[snafu(display(
+        "The configured API key does not allow cancelling queries. Use a key with write access."
+    ))]
+    WriteAccessRequired,
+
+    /// The request failed with an unexpected status code.
+    #[snafu(display("Request failed (HTTP {status_code}): {response_body}"))]
+    RequestFailed {
+        /// HTTP status code returned by the runtime.
+        status_code: u16,
+        /// Response body returned by the runtime.
+        response_body: String,
+    },
+
+    /// HTTP transport error.
+    #[snafu(display("Request failed: {message}"))]
+    HttpError { message: String },
+
+    /// The response could not be parsed.
+    #[snafu(display("Failed to parse response: {message}"))]
+    ParseError { message: String },
+}
+
+/// A synchronous query currently executing on the runtime.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ActiveQuery {
+    /// Server-assigned id, used to cancel the query.
+    pub query_id: String,
+    /// The protocol the query arrived on, such as `flight` or `http`.
+    pub protocol: String,
+    /// The query's SQL, truncated by the runtime for display.
+    pub sql_preview: String,
+    /// When the query started, in milliseconds since the Unix epoch.
+    pub started_at_ms: u64,
+}
+
+/// The set of synchronous queries the caller currently has running.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ActiveQueryList {
+    /// The active queries, most recently started first.
+    pub queries: Vec<ActiveQuery>,
+    /// Number of active queries reported by the runtime.
+    pub total_count: usize,
+}
+
+/// The runtime's response to a successful cancellation.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct CancelActiveQueryResponse {
+    /// The id of the query that was cancelled.
+    pub query_id: String,
+    /// The query's state after cancellation, such as `cancelled`.
+    pub status: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_an_active_query_list() {
+        let body = r#"{
+            "queries": [
+                {
+                    "query_id": "0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f70",
+                    "protocol": "flight",
+                    "sql_preview": "SELECT * FROM taxi_trips",
+                    "started_at_ms": 1750000000000
+                }
+            ],
+            "total_count": 1
+        }"#;
+
+        let list: ActiveQueryList = serde_json::from_str(body).expect("deserialize list");
+        assert_eq!(list.total_count, 1);
+        assert_eq!(list.queries.len(), 1);
+        assert_eq!(list.queries[0].protocol, "flight");
+        assert_eq!(list.queries[0].sql_preview, "SELECT * FROM taxi_trips");
+        assert_eq!(list.queries[0].started_at_ms, 1_750_000_000_000);
+    }
+
+    #[test]
+    fn deserializes_an_empty_active_query_list() {
+        let list: ActiveQueryList =
+            serde_json::from_str(r#"{"queries":[],"total_count":0}"#).expect("deserialize list");
+        assert_eq!(list.total_count, 0);
+        assert!(list.queries.is_empty());
+    }
+
+    #[test]
+    fn deserializes_a_cancel_response() {
+        let response: CancelActiveQueryResponse = serde_json::from_str(
+            r#"{"query_id":"0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f70","status":"cancelled"}"#,
+        )
+        .expect("deserialize cancel response");
+        assert_eq!(response.status, "cancelled");
+    }
+
+    #[test]
+    fn not_found_error_explains_both_causes() {
+        let message = ActiveQueryError::NotFound {
+            query_id: "abc".to_string(),
+        }
+        .to_string();
+        assert!(message.contains("abc"));
+        assert!(message.contains("already finished"));
+    }
+
+    #[test]
+    fn invalid_query_id_error_points_at_active_queries() {
+        let message = ActiveQueryError::InvalidQueryId {
+            query_id: "not-a-uuid".to_string(),
+        }
+        .to_string();
+        assert!(message.contains("not-a-uuid"));
+        assert!(message.contains("active_queries()"));
+    }
+}

--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -10,8 +10,34 @@
 //! The runtime assigns a `query_id` to every synchronous query but does not
 //! return it to the client that submitted it, so the two operations here are
 //! used together: list the active queries to find the one you want, then cancel
-//! it by id. Listing and cancellation are both scoped to the caller, so a client
-//! only ever sees and cancels its own queries.
+//! it by id.
+//!
+//! # Scope
+//!
+//! Two boundaries apply, and a query is reachable only inside both.
+//!
+//! **One runtime instance.** The runtime tracks active synchronous queries in
+//! memory, per instance, and these endpoints report only what the instance
+//! answering them knows. This client configures its Flight and HTTP endpoints
+//! independently, so behind a load balancer the query submitted over Flight may
+//! be running on a different instance than the one answering here — it will not
+//! be listed, and its id reports as not found. Point
+//! [`http_url()`](crate::ClientBuilder::http_url) at the instance running the
+//! query.
+//!
+//! **One authenticated principal**, not a [`Client`](crate::Client) instance.
+//! The principal is whatever credential the runtime authenticates — an API key
+//! or a client certificate — so every client presenting the same credential
+//! shares one scope and can list and cancel the others' queries. Only requests
+//! for which the runtime establishes no principal at all share the `public`
+//! scope. A query outside the caller's scope is reported as if it did not
+//! exist.
+//!
+//! **Runtime version.** Principal scoping on these two endpoints landed in
+//! [spiceai/spiceai#12841](https://github.com/spiceai/spiceai/pull/12841) and is
+//! in no runtime release up to and including `v2.1.5`. Against an earlier
+//! runtime both calls operate on every active query the instance holds, for any
+//! caller with write access.
 //!
 //! # Example
 //!
@@ -44,13 +70,13 @@ use snafu::Snafu;
 /// Errors that can occur while listing or cancelling active synchronous queries.
 #[derive(Debug, Snafu)]
 pub enum ActiveQueryError {
-    /// No active synchronous query with this id belongs to the caller.
+    /// No active synchronous query with this id is in the caller's scope.
     ///
-    /// The runtime reports a query submitted by another caller the same way it
-    /// reports one that does not exist, so a client cannot probe for other
-    /// callers' query ids.
+    /// The runtime reports a query submitted under another principal the same
+    /// way it reports one that does not exist, so a caller cannot probe for
+    /// other principals' query ids.
     #[snafu(display(
-        "No active query '{query_id}' found. It may have already finished, or it was submitted by a different client."
+        "No active query '{query_id}' found. It may have already finished, it was submitted under a different principal, or it is running on another runtime instance."
     ))]
     NotFound { query_id: String },
 
@@ -89,7 +115,8 @@ pub enum ActiveQueryError {
 pub struct ActiveQuery {
     /// Server-assigned id, used to cancel the query.
     pub query_id: String,
-    /// The protocol the query arrived on, such as `flight` or `http`.
+    /// The protocol the query arrived on: `http`, `flight`, `flightsql`, or
+    /// `internal`.
     pub protocol: String,
     /// The query's SQL, truncated by the runtime for display.
     pub sql_preview: String,
@@ -104,6 +131,28 @@ pub struct ActiveQueryList {
     pub queries: Vec<ActiveQuery>,
     /// Number of active queries reported by the runtime.
     pub total_count: usize,
+}
+
+/// Whether `query_id` has the shape the runtime parses as a UUID.
+///
+/// The ids this SDK cancels always come from [`ActiveQuery::query_id`], so a
+/// value that is not a UUID cannot name a running query. Checking locally keeps
+/// such a value out of the request path entirely: `.` and `..` are unreserved,
+/// so percent-encoding leaves them intact and the URL parser then resolves them
+/// away — `..` turns `/v1/sql/{id}/cancel` into a POST at a route the caller
+/// never asked for.
+pub(crate) fn is_uuid(query_id: &str) -> bool {
+    let bytes = query_id.as_bytes();
+    if bytes.len() != 36 {
+        return false;
+    }
+    bytes.iter().enumerate().all(|(index, byte)| {
+        if matches!(index, 8 | 13 | 18 | 23) {
+            *byte == b'-'
+        } else {
+            byte.is_ascii_hexdigit()
+        }
+    })
 }
 
 /// The runtime's response to a successful cancellation.
@@ -166,6 +215,32 @@ mod tests {
         .to_string();
         assert!(message.contains("abc"));
         assert!(message.contains("already finished"));
+    }
+
+    #[test]
+    fn is_uuid_accepts_the_ids_the_runtime_hands_out() {
+        assert!(is_uuid("0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f70"));
+        // The runtime parses either case.
+        assert!(is_uuid("0198F0A1-9C3D-7C4E-8A11-2B3C4D5E6F70"));
+    }
+
+    #[test]
+    fn is_uuid_rejects_anything_that_could_reroute_a_request() {
+        for id in [
+            "",
+            ".",
+            "..",
+            "../queries/escape",
+            "not-a-uuid",
+            // Right length, wrong shape: hyphens off their positions.
+            "0198f0a19c3d-7c4e-8a11-2b3c4d5e6f70-",
+            // Right shape, a non-hex digit.
+            "0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f7g",
+            // A trailing segment appended to a valid id.
+            "0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f70/cancel",
+        ] {
+            assert!(!is_uuid(id), "{id:?} should not be accepted as a UUID");
+        }
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -542,8 +542,12 @@ impl SpiceClient {
     ///
     /// The runtime does not return a query's id to the client that submitted it,
     /// so this is how you find the id needed by
-    /// [`cancel_active_query()`](Self::cancel_active_query). Results are scoped to
-    /// this client — another caller's in-flight queries are never listed.
+    /// [`cancel_active_query()`](Self::cancel_active_query).
+    ///
+    /// Results cover one runtime instance — the one [`http_url()`](SpiceClientBuilder::http_url)
+    /// addresses — and are scoped to the **authenticated principal**, not to this
+    /// client: every client presenting the same credential sees the same queries.
+    /// See [`active_query`](crate::active_query) for the full boundary.
     ///
     /// **Note:** Requires [`http_url()`](SpiceClientBuilder::http_url) to be configured.
     ///
@@ -585,8 +589,10 @@ impl SpiceClient {
     /// Takes a `query_id` from [`active_queries()`](Self::active_queries). To cancel
     /// an async query job instead, use [`cancel_query()`](Self::cancel_query).
     ///
-    /// Cancellation is scoped to this client: an id belonging to another caller is
-    /// reported as not found rather than cancelled.
+    /// Cancellation reaches the runtime instance [`http_url()`](SpiceClientBuilder::http_url)
+    /// addresses, and is scoped to the **authenticated principal**, not to this
+    /// client: any client presenting the same credential can cancel the query, while
+    /// an id outside that scope is reported as not found rather than cancelled.
     ///
     /// **Note:** Requires [`http_url()`](SpiceClientBuilder::http_url) to be configured.
     ///
@@ -611,7 +617,7 @@ impl SpiceClient {
     ///
     /// # Errors
     ///
-    /// - [`ActiveQueryError::NotFound`] if no such query is running for this client
+    /// - [`ActiveQueryError::NotFound`] if no such query is running in the caller's scope
     /// - [`ActiveQueryError::InvalidQueryId`] if `query_id` is not a UUID
     /// - [`ActiveQueryError::WriteAccessRequired`] if the API key lacks write access
     pub async fn cancel_active_query(
@@ -899,7 +905,7 @@ mod tests {
     use serde_json::json;
     use std::time::Duration;
     use tonic::transport::Endpoint;
-    use wiremock::matchers::{body_json, method, path, query_param};
+    use wiremock::matchers::{body_json, method, path, path_regex, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn test_client(http_base_url: Option<&str>) -> SpiceClient {
@@ -1502,5 +1508,237 @@ mod tests {
             .await
             .expect("refresh dataset with explicit overrides");
         assert_eq!(custom_refresh.message, "Refresh scheduled");
+    }
+
+    #[tokio::test]
+    async fn test_active_queries_lists_from_the_runtime() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/sql/active"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "queries": [
+                    {
+                        "query_id": "0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f70",
+                        "protocol": "flightsql",
+                        "sql_preview": "SELECT * FROM taxi_trips",
+                        "started_at_ms": 1_750_000_000_000_u64
+                    }
+                ],
+                "total_count": 1
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(Some(&server.uri()));
+        let active = client
+            .active_queries()
+            .await
+            .expect("list the active queries");
+
+        assert_eq!(active.total_count, 1);
+        assert_eq!(
+            active.queries[0].query_id,
+            "0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f70"
+        );
+        assert_eq!(active.queries[0].protocol, "flightsql");
+    }
+
+    #[tokio::test]
+    async fn test_active_queries_maps_a_forbidden_response() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/sql/active"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("write access required"))
+            .mount(&server)
+            .await;
+
+        let client = test_client(Some(&server.uri()));
+        let err = client
+            .active_queries()
+            .await
+            .expect_err("a 403 should not list queries");
+
+        assert!(matches!(err, ActiveQueryError::WriteAccessRequired));
+    }
+
+    #[tokio::test]
+    async fn test_active_queries_reports_an_unconfigured_http_endpoint() {
+        let client = test_client(None);
+        let err = client
+            .active_queries()
+            .await
+            .expect_err("listing needs an HTTP endpoint");
+
+        match err {
+            ActiveQueryError::HttpError { message } => {
+                assert!(message.contains("http_url()"), "unexpected: {message}");
+            }
+            other => panic!("expected an HttpError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cancel_active_query_posts_to_the_cancel_route() {
+        let server = MockServer::start().await;
+        let query_id = "0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f70";
+
+        Mock::given(method("POST"))
+            .and(path(format!("/v1/sql/{query_id}/cancel")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "query_id": query_id,
+                "status": "cancelled"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(Some(&server.uri()));
+        let cancelled = client
+            .cancel_active_query(query_id)
+            .await
+            .expect("cancel the active query");
+
+        assert_eq!(cancelled.query_id, query_id);
+        assert_eq!(cancelled.status, "cancelled");
+    }
+
+    #[tokio::test]
+    async fn test_cancel_active_query_maps_each_error_status() {
+        let server = MockServer::start().await;
+
+        // Every id here is a well-formed UUID, so each reaches the runtime and
+        // exercises the status mapping rather than the local shape check.
+        const FORBIDDEN: &str = "0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f71";
+        const MISSING: &str = "0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f72";
+        const REJECTED: &str = "0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f73";
+
+        for (id, status) in [(REJECTED, 400), (FORBIDDEN, 403), (MISSING, 404)] {
+            Mock::given(method("POST"))
+                .and(path(format!("/v1/sql/{id}/cancel")))
+                .respond_with(ResponseTemplate::new(status))
+                .mount(&server)
+                .await;
+        }
+
+        let client = test_client(Some(&server.uri()));
+
+        assert!(matches!(
+            client
+                .cancel_active_query(REJECTED)
+                .await
+                .expect_err("400 maps to InvalidQueryId"),
+            ActiveQueryError::InvalidQueryId { query_id } if query_id == REJECTED
+        ));
+        assert!(matches!(
+            client
+                .cancel_active_query(FORBIDDEN)
+                .await
+                .expect_err("403 maps to WriteAccessRequired"),
+            ActiveQueryError::WriteAccessRequired
+        ));
+        assert!(matches!(
+            client
+                .cancel_active_query(MISSING)
+                .await
+                .expect_err("404 maps to NotFound"),
+            ActiveQueryError::NotFound { query_id } if query_id == MISSING
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_cancel_active_query_rejects_an_id_that_could_reroute_the_request() {
+        let server = MockServer::start().await;
+
+        // Any request at all is a failure here: `.` and `..` survive
+        // percent-encoding and the URL parser then resolves them away, so an id
+        // like `..` would turn this POST into one at `/v1/sql/cancel`.
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "query_id": "rerouted",
+                "status": "cancelled"
+            })))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let client = test_client(Some(&server.uri()));
+
+        for id in ["..", ".", "../queries/escape", "not-a-uuid", ""] {
+            let err = client
+                .cancel_active_query(id)
+                .await
+                .expect_err("an id that is not a UUID cannot cancel a query");
+
+            assert!(
+                matches!(err, ActiveQueryError::InvalidQueryId { ref query_id } if query_id == id),
+                "id {id:?} produced {err:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_async_query_id_cannot_reroute_a_request_onto_another_endpoint() {
+        let server = MockServer::start().await;
+
+        // The routes a query id must never be able to reach. `..` is resolved
+        // away by the URL parser and `#` truncates the path at the fragment, so
+        // an id formatted into a path string chooses the route — and the client
+        // attaches its API key to whatever it then calls.
+        for route in [
+            "/v1/datasets/orders/acceleration/refresh",
+            "/v1/sql/0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f70/cancel",
+            "/v1/cancel",
+            "/v1/queries",
+        ] {
+            Mock::given(path(route))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(json!({"message": "rerouted"})),
+                )
+                .expect(0)
+                .mount(&server)
+                .await;
+        }
+
+        // Anything that does reach the intended route is the runtime's to
+        // refuse, and it answers 404 for an id no job carries.
+        Mock::given(path_regex(r"^/v1/queries/[^/]+(/.*)?$"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let client = test_client(Some(&server.uri()));
+
+        for id in [
+            "..",
+            ".",
+            "../datasets/orders/acceleration/refresh#",
+            "../sql/0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f70",
+        ] {
+            let job = client.get_query(id).expect("create query handle");
+
+            assert!(job.cancel().await.is_err(), "cancel accepted the id {id:?}");
+            assert!(job.status().await.is_err(), "status accepted the id {id:?}");
+            assert!(
+                job.results().await.is_err(),
+                "results accepted the id {id:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cancel_active_query_reports_an_unconfigured_http_endpoint() {
+        let client = test_client(None);
+        let err = client
+            .cancel_active_query("0198f0a1-9c3d-7c4e-8a11-2b3c4d5e6f70")
+            .await
+            .expect_err("cancellation needs an HTTP endpoint");
+
+        match err {
+            ActiveQueryError::HttpError { message } => {
+                assert!(message.contains("http_url()"), "unexpected: {message}");
+            }
+            other => panic!("expected an HttpError, got {other:?}"),
+        }
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,3 +1,4 @@
+use crate::active_query::{ActiveQueryError, ActiveQueryList, CancelActiveQueryResponse};
 use crate::flight::RetryableQueryStream;
 use crate::params::{QueryParameterError, QueryParameters};
 use crate::query::{QueryError, QueryHttpClient, QueryJob, QuerySubmitOptions};
@@ -531,6 +532,101 @@ impl SpiceClient {
 
         let job = QueryJob::new(query_id.to_string(), Arc::clone(http_client));
         job.cancel().await
+    }
+
+    /// Lists the *synchronous* queries this client currently has running.
+    ///
+    /// Synchronous queries are the ones started by [`sql()`](Self::sql), FlightSQL,
+    /// `/v1/sql`, NSQL, and search. For async query jobs, use
+    /// [`queries()`](Self::queries) instead.
+    ///
+    /// The runtime does not return a query's id to the client that submitted it,
+    /// so this is how you find the id needed by
+    /// [`cancel_active_query()`](Self::cancel_active_query). Results are scoped to
+    /// this client — another caller's in-flight queries are never listed.
+    ///
+    /// **Note:** Requires [`http_url()`](SpiceClientBuilder::http_url) to be configured.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use spiceai::ClientBuilder;
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// let client = ClientBuilder::new()
+    ///     .http_url("http://localhost:8090")
+    ///     .build()
+    ///     .await?;
+    ///
+    /// let active = client.active_queries().await?;
+    /// println!("{} queries running", active.total_count);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// - [`ActiveQueryError::WriteAccessRequired`] if the API key lacks write access
+    /// - [`ActiveQueryError::HttpError`] if the HTTP endpoint is not configured or unreachable
+    pub async fn active_queries(&self) -> Result<ActiveQueryList, ActiveQueryError> {
+        let http_client = self
+            .http_client
+            .as_ref()
+            .ok_or(ActiveQueryError::HttpError {
+                message: "HTTP endpoint not configured. Use ClientBuilder::http_url() to set it."
+                    .to_string(),
+            })?;
+
+        http_client.list_active_queries().await
+    }
+
+    /// Cancels a running *synchronous* query by id.
+    ///
+    /// Takes a `query_id` from [`active_queries()`](Self::active_queries). To cancel
+    /// an async query job instead, use [`cancel_query()`](Self::cancel_query).
+    ///
+    /// Cancellation is scoped to this client: an id belonging to another caller is
+    /// reported as not found rather than cancelled.
+    ///
+    /// **Note:** Requires [`http_url()`](SpiceClientBuilder::http_url) to be configured.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use spiceai::ClientBuilder;
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// let client = ClientBuilder::new()
+    ///     .http_url("http://localhost:8090")
+    ///     .build()
+    ///     .await?;
+    ///
+    /// let active = client.active_queries().await?;
+    /// for query in active.queries {
+    ///     client.cancel_active_query(&query.query_id).await?;
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// - [`ActiveQueryError::NotFound`] if no such query is running for this client
+    /// - [`ActiveQueryError::InvalidQueryId`] if `query_id` is not a UUID
+    /// - [`ActiveQueryError::WriteAccessRequired`] if the API key lacks write access
+    pub async fn cancel_active_query(
+        &self,
+        query_id: &str,
+    ) -> Result<CancelActiveQueryResponse, ActiveQueryError> {
+        let http_client = self
+            .http_client
+            .as_ref()
+            .ok_or(ActiveQueryError::HttpError {
+                message: "HTTP endpoint not configured. Use ClientBuilder::http_url() to set it."
+                    .to_string(),
+            })?;
+
+        http_client.cancel_active_query(query_id).await
     }
 
     /// Triggers an on-demand refresh for an accelerated dataset.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 
+pub mod active_query;
 mod client;
 mod config;
 mod dataset;
@@ -10,6 +11,7 @@ mod redirect;
 pub mod tls;
 mod util;
 
+pub use active_query::{ActiveQuery, ActiveQueryError, ActiveQueryList, CancelActiveQueryResponse};
 pub use arrow;
 pub use client::Error as SpiceClientError;
 pub use client::SpiceClient as Client;

--- a/src/query.rs
+++ b/src/query.rs
@@ -489,6 +489,40 @@ impl QueryHttpClient {
         }
     }
 
+    /// Build a runtime URL whose path is `segments`, with every segment encoded.
+    ///
+    /// Formatting a caller-supplied id into a path string lets that id choose the
+    /// route. `..` is resolved away by the URL parser, and a `#` truncates the
+    /// path at the fragment, so an id of
+    /// `../datasets/orders/acceleration/refresh#` turns
+    /// `/v1/queries/{id}/cancel` into a POST at
+    /// `/v1/datasets/orders/acceleration/refresh` — with this client's API key
+    /// attached. Pushing segments encodes `/`, `?` and `#`; the explicit `.`
+    /// and `..` rejection covers the two the encoder leaves alone because they
+    /// are unreserved.
+    fn build_url<'a>(
+        &self,
+        segments: impl IntoIterator<Item = &'a str>,
+    ) -> Result<reqwest::Url, QueryError> {
+        let mut url = reqwest::Url::parse(&self.base_url).map_err(|e| QueryError::HttpError {
+            message: e.to_string(),
+        })?;
+        {
+            let mut path = url.path_segments_mut().map_err(|_| QueryError::HttpError {
+                message: format!("Base URL {} cannot carry a path", self.base_url),
+            })?;
+            for segment in segments {
+                if segment == "." || segment == ".." {
+                    return Err(QueryError::HttpError {
+                        message: format!("Invalid path segment {segment:?} in request URL"),
+                    });
+                }
+                path.push(segment);
+            }
+        }
+        Ok(url)
+    }
+
     pub async fn submit(
         &self,
         sql: &str,
@@ -505,7 +539,7 @@ impl QueryHttpClient {
         };
 
         let response = self
-            .add_auth(self.client.post(&url))
+            .add_auth(self.client.post(url))
             .json(&body)
             .send()
             .await
@@ -529,10 +563,10 @@ impl QueryHttpClient {
     }
 
     pub async fn get_status(&self, query_id: &str) -> Result<StatusResponse, QueryError> {
-        let url = format!("{}/v1/queries/{}/status", self.base_url, query_id);
+        let url = self.build_url(["v1", "queries", query_id, "status"])?;
 
         let response = self
-            .add_auth(self.client.get(&url))
+            .add_auth(self.client.get(url))
             .send()
             .await
             .map_err(|e| QueryError::HttpError {
@@ -557,10 +591,10 @@ impl QueryHttpClient {
     }
 
     pub async fn get_query(&self, query_id: &str) -> Result<QueryInfoResponse, QueryError> {
-        let url = format!("{}/v1/queries/{}", self.base_url, query_id);
+        let url = self.build_url(["v1", "queries", query_id])?;
 
         let response = self
-            .add_auth(self.client.get(&url))
+            .add_auth(self.client.get(url))
             .send()
             .await
             .map_err(|e| QueryError::HttpError {
@@ -593,13 +627,17 @@ impl QueryHttpClient {
         query_id: &str,
         chunk_index: usize,
     ) -> Result<ResultChunkResponse, QueryError> {
-        let url = format!(
-            "{}/v1/queries/{}/results/chunks/{}",
-            self.base_url, query_id, chunk_index
-        );
+        let url = self.build_url([
+            "v1",
+            "queries",
+            query_id,
+            "results",
+            "chunks",
+            &chunk_index.to_string(),
+        ])?;
 
         let response = self
-            .add_auth(self.client.get(&url))
+            .add_auth(self.client.get(url))
             .send()
             .await
             .map_err(|e| QueryError::HttpError {
@@ -635,13 +673,17 @@ impl QueryHttpClient {
         chunk_index: usize,
         schema: &SchemaRef,
     ) -> Result<Vec<RecordBatch>, QueryError> {
-        let url = format!(
-            "{}/v1/queries/{}/results/chunks/{}",
-            self.base_url, query_id, chunk_index
-        );
+        let url = self.build_url([
+            "v1",
+            "queries",
+            query_id,
+            "results",
+            "chunks",
+            &chunk_index.to_string(),
+        ])?;
 
         let response = self
-            .add_auth(self.client.get(&url))
+            .add_auth(self.client.get(url))
             .send()
             .await
             .map_err(|e| QueryError::HttpError {
@@ -676,10 +718,10 @@ impl QueryHttpClient {
     }
 
     pub async fn cancel(&self, query_id: &str) -> Result<QueryInfoResponse, QueryError> {
-        let url = format!("{}/v1/queries/{}/cancel", self.base_url, query_id);
+        let url = self.build_url(["v1", "queries", query_id, "cancel"])?;
 
         let response = self
-            .add_auth(self.client.post(&url))
+            .add_auth(self.client.post(url))
             .send()
             .await
             .map_err(|e| QueryError::HttpError {
@@ -742,10 +784,35 @@ impl QueryHttpClient {
         &self,
         query_id: &str,
     ) -> Result<CancelActiveQueryResponse, ActiveQueryError> {
-        let url = format!("{}/v1/sql/{query_id}/cancel", self.base_url);
+        // `query_id` is caller input, and it reaches the runtime as a path
+        // segment. Reject anything that is not a UUID here rather than building
+        // a URL from it: a `.` or `..` survives percent-encoding and is then
+        // resolved away by the URL parser, which would send this POST to a
+        // route the caller never named.
+        if !crate::active_query::is_uuid(query_id) {
+            return Err(ActiveQueryError::InvalidQueryId {
+                query_id: query_id.to_string(),
+            });
+        }
+
+        let mut url =
+            reqwest::Url::parse(&self.base_url).map_err(|e| ActiveQueryError::HttpError {
+                message: e.to_string(),
+            })?;
+        {
+            let mut path_segments =
+                url.path_segments_mut()
+                    .map_err(|_| ActiveQueryError::HttpError {
+                        message: "Base URL cannot be used to cancel a query".to_string(),
+                    })?;
+            path_segments.push("v1");
+            path_segments.push("sql");
+            path_segments.push(query_id);
+            path_segments.push("cancel");
+        }
 
         let response = self
-            .add_auth(self.client.post(&url))
+            .add_auth(self.client.post(url))
             .send()
             .await
             .map_err(|e| ActiveQueryError::HttpError {

--- a/src/query.rs
+++ b/src/query.rs
@@ -33,6 +33,7 @@
 //! }
 //! ```
 
+use crate::active_query::{ActiveQueryError, ActiveQueryList, CancelActiveQueryResponse};
 use crate::dataset::{DatasetError, DatasetRefreshRequest, DatasetRefreshResponse};
 use crate::params::{QueryParameterError, QueryParameters};
 use arrow::array::RecordBatch;
@@ -699,6 +700,75 @@ impl QueryHttpClient {
             status_code => {
                 let response_body = response.text().await.unwrap_or_default();
                 Err(QueryError::HttpRequestFailed {
+                    status_code,
+                    response_body,
+                })
+            }
+        }
+    }
+
+    /// List the synchronous queries the caller currently has running.
+    pub async fn list_active_queries(&self) -> Result<ActiveQueryList, ActiveQueryError> {
+        let url = format!("{}/v1/sql/active", self.base_url);
+
+        let response = self
+            .add_auth(self.client.get(&url))
+            .send()
+            .await
+            .map_err(|e| ActiveQueryError::HttpError {
+                message: e.to_string(),
+            })?;
+
+        match response.status().as_u16() {
+            200 => response
+                .json()
+                .await
+                .map_err(|e| ActiveQueryError::ParseError {
+                    message: e.to_string(),
+                }),
+            403 => Err(ActiveQueryError::WriteAccessRequired),
+            status_code => {
+                let response_body = response.text().await.unwrap_or_default();
+                Err(ActiveQueryError::RequestFailed {
+                    status_code,
+                    response_body,
+                })
+            }
+        }
+    }
+
+    /// Cancel a running synchronous query by id.
+    pub async fn cancel_active_query(
+        &self,
+        query_id: &str,
+    ) -> Result<CancelActiveQueryResponse, ActiveQueryError> {
+        let url = format!("{}/v1/sql/{query_id}/cancel", self.base_url);
+
+        let response = self
+            .add_auth(self.client.post(&url))
+            .send()
+            .await
+            .map_err(|e| ActiveQueryError::HttpError {
+                message: e.to_string(),
+            })?;
+
+        match response.status().as_u16() {
+            200 => response
+                .json()
+                .await
+                .map_err(|e| ActiveQueryError::ParseError {
+                    message: e.to_string(),
+                }),
+            400 => Err(ActiveQueryError::InvalidQueryId {
+                query_id: query_id.to_string(),
+            }),
+            403 => Err(ActiveQueryError::WriteAccessRequired),
+            404 => Err(ActiveQueryError::NotFound {
+                query_id: query_id.to_string(),
+            }),
+            status_code => {
+                let response_body = response.text().await.unwrap_or_default();
+                Err(ActiveQueryError::RequestFailed {
                     status_code,
                     response_body,
                 })


### PR DESCRIPTION
## What

Adds `Client::active_queries()` and `Client::cancel_active_query()`, wrapping the runtime's `GET /v1/sql/active` and `POST /v1/sql/{query_id}/cancel`.

## Why

Cancelling a running *synchronous* query — one started by `sql()`, FlightSQL, `/v1/sql`, NSQL, or search — was not reachable from this SDK. The existing `cancel_query()` cancels an async *job* via `/v1/queries/{id}/cancel`, which is a different thing and is gated on the runtime running in cluster mode. The two endpoints added here work on a default single-node runtime, so this closes a gap users hit today.

They ship as a pair deliberately: the runtime assigns a `query_id` to every synchronous query but does not return it to the client that submitted it, so `active_queries()` is the only way to discover the id that cancellation needs. Shipping cancel alone would leave it unreachable.

Both endpoints are scoped to the caller by the runtime, so a client only ever lists and cancels its own queries — that's reflected in the docs and in the `NotFound` error text, since an id belonging to another caller is reported as not found rather than cancelled.

Kept in a new `active_query` module rather than folded into `query`, so the sync/async distinction stays legible at the type level: `ActiveQueryError` carries only variants that can actually occur here (no `ClusterModeRequired`, no `Expired`).

Part of aligning query cancellation across the SDKs — no SDK had this, so this establishes the shape (`active_queries` / `cancel_active_query`, named after the runtime's own operation ids) for the others to mirror.

## Verification

- [x] `cargo build`
- [x] `cargo test --lib` — 196 passed, including 5 new tests for response deserialization and error text
- [x] `cargo test --doc` — 29 passed, including the new README example
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-features` — clean
- [ ] Integration tests (`cargo test`) — **not run**: they need a live runtime on `127.0.0.1:50051` and no `spice` CLI is available in this environment. The 7 pre-existing failures there are all connection-refused and are unrelated to this change.

## Review gate

Attests the review-fix commit `0206785`, not the original feature work.

- **Adversarial review**: `codex`, two passes — `1c6a068` (verdict `needs-attention`) and the re-run after the approach changed. Findings triaged on the review threads:
  - Accepted: the corrected scope wording still misstated the boundary for mTLS-authenticated clients, and omitted the runtime-instance boundary. Both fixed.
  - Accepted, and the largest change here: the path-hardening covered only `cancel_active_query`, leaving `QueryHttpClient::cancel` / `get_status` / `get_query` / the chunk readers formatting a caller-supplied id into the path — reproduced as an authenticated POST landing on `/v1/datasets/{name}/acceleration/refresh`. All query-id routes now build URLs through `build_url`.
  - Deferred with an issue: cluster-wide active-query lookup is a runtime gap, not an SDK one — **spiceai/spiceai#13026**.
- **Security review**: covered by the above — the diff is documentation plus URL construction, and the URL-construction defect *is* the security finding, reproduced and regression-tested rather than argued.
- **Local gate**: `cargo fmt --check`, `cargo clippy --all-targets`, `cargo test --lib` (206 passed), `cargo test --doc` (29 passed). The 7 `client_test::tests::test_local_*` failures need a running local runtime and fail identically with this diff stashed.
