### PR TITLE
feat: add nsql and nsql_generate_sql for the runtime's /v1/nsql endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,69 @@ Adding `with_keywords([...])` runs a lexical pass alongside the vector pass, whi
 
 Each `SearchMatch` carries `dataset`, `score` (higher is more similar), `matches` (matched values keyed by source column — a list per column, since one column can contribute several chunks to a match), `primary_key`, `data`, and `metadata`.
 
+### Text-to-SQL (NSQL)
+
+`nsql()` answers a question in natural language: the configured LLM generates SQL, the
+runtime runs it read-only, and both the rows and the generated query come back. It needs
+an LLM model in the Spicepod — see [Text to SQL](https://docs.spice.ai/features/text-to-sql)
+for how to configure one.
+
+```rust,no_run
+use spiceai::{ClientBuilder, NsqlRequest};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+  let client = ClientBuilder::new()
+    .http_url("http://localhost:8090")
+    .build()
+    .await?;
+
+  let response = client
+    .nsql(NsqlRequest::new("top 5 customers by revenue").with_datasets(["sales"]))
+    .await?;
+
+  println!("generated SQL: {}", response.sql);
+  for row in response {
+    println!("{row:?}");
+  }
+
+  Ok(())
+}
+```
+
+`NsqlRequest` takes the question plus `with_model()` (needed only when the Spicepod
+configures more than one compatible model), `with_datasets()` (a hint about what to
+sample for the model's context — it does not restrict which tables the generated query
+may reference), `with_sample_data()`, and `with_prompt_cache_key()`.
+
+Rows in `data` are decoded from JSON, so they carry JSON's types rather than the Arrow
+types named in `schema`. When Arrow types matter, generate the query and run it yourself
+— which is also how to inspect or edit a generated query before it runs:
+
+```rust,no_run
+use spiceai::{ClientBuilder, NsqlRequest, StreamExt};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+  let client = ClientBuilder::new()
+    .http_url("http://localhost:8090")
+    .build()
+    .await?;
+
+  let sql = client
+    .nsql_generate_sql(NsqlRequest::new("top 5 customers by revenue"))
+    .await?;
+  println!("{sql}");
+
+  let mut stream = client.sql(&sql).await?;
+  while let Some(batch) = stream.next().await {
+    println!("rows: {}", batch?.num_rows());
+  }
+
+  Ok(())
+}
+```
+
 ### Runtime health and status
 
 `is_ready()` is a single boolean for the whole runtime. When you need to know *which*

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,6 +7,7 @@ use crate::{
     config::{GenericError, SPICE_CLOUD_FLIGHT_ADDR, SPICE_LOCAL_FLIGHT_ADDR},
     dataset::{DatasetError, DatasetRefreshRequest, DatasetRefreshResponse},
     flight::{SqlFlightClient, is_connection_reset_generic_error},
+    nsql::{NsqlError, NsqlRequest, NsqlResponse},
     search::{SearchError, SearchRequest, SearchResponse},
     status::{ConnectionDetails, StatusError},
     tls::{FlightChannelBuilder, ensure_crypto_provider, new_tls_flight_channel},
@@ -729,6 +730,94 @@ impl SpiceClient {
         http_client.search(&request).await
     }
 
+    /// Answers a natural-language question by generating SQL and running it.
+    ///
+    /// Backed by `POST /v1/nsql`: the configured LLM translates the question,
+    /// the runtime executes the result read-only, and both the rows and the
+    /// generated SQL come back. Requires an LLM model in the Spicepod — see
+    /// [Text to SQL](https://docs.spice.ai/features/text-to-sql) for how to
+    /// configure one.
+    ///
+    /// **Note:** Requires [`http_url()`](SpiceClientBuilder::http_url) to be configured.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use spiceai::{ClientBuilder, NsqlRequest};
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// let client = ClientBuilder::new()
+    ///     .http_url("http://localhost:8090")
+    ///     .build()
+    ///     .await?;
+    ///
+    /// let response = client
+    ///     .nsql(NsqlRequest::new("top 5 customers by revenue").with_datasets(["sales"]))
+    ///     .await?;
+    ///
+    /// println!("generated SQL: {}", response.sql);
+    /// for row in response {
+    ///     println!("{row:?}");
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// - [`NsqlError::InvalidRequest`] if the request has an empty query
+    /// - [`NsqlError::HttpError`] if the HTTP endpoint is not configured or unreachable
+    /// - [`NsqlError::NsqlFailed`] if the runtime rejects the request, which is
+    ///   what a missing or ambiguous model reports as
+    pub async fn nsql(&self, request: NsqlRequest) -> Result<NsqlResponse, NsqlError> {
+        let http_client = self.http_client.as_ref().ok_or(NsqlError::HttpError {
+            message: "HTTP endpoint not configured. Use ClientBuilder::http_url() to set it."
+                .to_string(),
+        })?;
+
+        http_client.nsql(&request).await
+    }
+
+    /// Translates a natural-language question into SQL without running it.
+    ///
+    /// Use it to inspect or edit the query before running it, or to run it
+    /// through [`query`](Self::query) or the Flight path so results arrive as
+    /// Arrow rather than decoded JSON.
+    ///
+    /// **Note:** Requires [`http_url()`](SpiceClientBuilder::http_url) to be configured.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use spiceai::{ClientBuilder, NsqlRequest};
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// let client = ClientBuilder::new()
+    ///     .http_url("http://localhost:8090")
+    ///     .build()
+    ///     .await?;
+    ///
+    /// let sql = client
+    ///     .nsql_generate_sql(NsqlRequest::new("top 5 customers by revenue"))
+    ///     .await?;
+    ///
+    /// println!("{sql}");
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Same as [`nsql`](Self::nsql).
+    pub async fn nsql_generate_sql(&self, request: NsqlRequest) -> Result<String, NsqlError> {
+        let http_client = self.http_client.as_ref().ok_or(NsqlError::HttpError {
+            message: "HTTP endpoint not configured. Use ClientBuilder::http_url() to set it."
+                .to_string(),
+        })?;
+
+        http_client.nsql_generate_sql(&request).await
+    }
+
     /// Returns the status of each runtime connection.
     ///
     /// Backed by `GET /v1/status`. Where [`is_ready`](Self::is_ready) reports a single
@@ -1003,7 +1092,7 @@ mod tests {
     use serde_json::json;
     use std::time::Duration;
     use tonic::transport::Endpoint;
-    use wiremock::matchers::{body_json, method, path, path_regex, query_param};
+    use wiremock::matchers::{body_json, header, method, path, path_regex, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn test_client(http_base_url: Option<&str>) -> SpiceClient {
@@ -1717,6 +1806,138 @@ mod tests {
             .search(SearchRequest::new("tokyo"))
             .await
             .expect_err("search without an HTTP endpoint fails");
+        assert!(err.to_string().contains("http_url"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn test_nsql_posts_request_and_parses_response() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/nsql"))
+            // Without this media type the runtime answers with a bare array of
+            // rows and the generated SQL is lost, so pin it.
+            .and(header("accept", "application/vnd.spiceai.nsql.v1+json"))
+            .and(body_json(json!({
+                "query": "top 5 customers by revenue",
+                "datasets": ["sales"],
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "row_count": 2,
+                "schema": {
+                    "fields": [
+                        {"name": "customer_id", "data_type": "Utf8", "nullable": false},
+                        {"name": "total", "data_type": "Int64", "nullable": false}
+                    ]
+                },
+                "data": [
+                    {"customer_id": "12345", "total": 150_000},
+                    {"customer_id": "67890", "total": 125_000}
+                ],
+                "sql": "SELECT customer_id, sum(total) AS total FROM sales GROUP BY customer_id"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(Some(&server.uri()));
+
+        let response = client
+            .nsql(NsqlRequest::new("top 5 customers by revenue").with_datasets(["sales"]))
+            .await
+            .expect("nsql succeeds");
+
+        assert_eq!(
+            response.sql,
+            "SELECT customer_id, sum(total) AS total FROM sales GROUP BY customer_id"
+        );
+        assert_eq!(response.row_count, 2);
+        assert_eq!(response.len(), 2);
+        assert_eq!(response.data[0]["customer_id"], "12345");
+        assert_eq!(response.schema.fields.len(), 2);
+        assert_eq!(response.schema.fields[0].data_type, "Utf8");
+    }
+
+    #[tokio::test]
+    async fn test_nsql_generate_sql_requests_the_sql_media_type() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/nsql"))
+            .and(header("accept", "application/sql"))
+            .respond_with(
+                // This media type answers with the bare query text.
+                ResponseTemplate::new(200).set_body_string("\n  SELECT count(*) FROM orders\n"),
+            )
+            .mount(&server)
+            .await;
+
+        let client = test_client(Some(&server.uri()));
+
+        let sql = client
+            .nsql_generate_sql(NsqlRequest::new("how many orders"))
+            .await
+            .expect("nsql_generate_sql succeeds");
+
+        assert_eq!(sql, "SELECT count(*) FROM orders");
+    }
+
+    #[tokio::test]
+    async fn test_nsql_surfaces_runtime_error_body() {
+        let server = MockServer::start().await;
+
+        // A missing or ambiguous model is the most common NSQL failure and the
+        // runtime explains it in the body.
+        Mock::given(method("POST"))
+            .and(path("/v1/nsql"))
+            .respond_with(
+                ResponseTemplate::new(400).set_body_string(
+                    "No model specified and no compatible LLM model is configured.",
+                ),
+            )
+            .mount(&server)
+            .await;
+
+        let client = test_client(Some(&server.uri()));
+
+        let err = client
+            .nsql(NsqlRequest::new("how many orders"))
+            .await
+            .expect_err("runtime rejects the request");
+
+        let message = err.to_string();
+        assert!(message.contains("No model specified"), "{message}");
+        assert!(message.contains("400"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn test_nsql_validates_before_sending() {
+        let server = MockServer::start().await;
+        // No mock is mounted: a request reaching the server fails the test.
+        let client = test_client(Some(&server.uri()));
+
+        let err = client
+            .nsql(NsqlRequest::new("   "))
+            .await
+            .expect_err("empty query is rejected");
+        assert!(err.to_string().contains("non-empty"), "{err}");
+
+        assert!(
+            server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_nsql_requires_http_url() {
+        let client = test_client(None);
+
+        let err = client
+            .nsql(NsqlRequest::new("how many orders"))
+            .await
+            .expect_err("nsql without an HTTP endpoint fails");
         assert!(err.to_string().contains("http_url"), "{err}");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod client;
 mod config;
 mod dataset;
 mod flight;
+pub mod nsql;
 mod params;
 pub mod query;
 mod redirect;
@@ -21,6 +22,7 @@ pub use client::SpiceClientBuilder as ClientBuilder;
 pub use dataset::{
     DatasetError, DatasetRefreshMode, DatasetRefreshRequest, DatasetRefreshResponse,
 };
+pub use nsql::{NsqlError, NsqlField, NsqlRequest, NsqlResponse, NsqlSchema};
 pub use params::{QueryParameter, QueryParameterError, QueryParameters};
 pub use query::{
     QueryError, QueryInfo, QueryJob, QueryListResponse, QueryResult, QueryResultStream,

--- a/src/nsql.rs
+++ b/src/nsql.rs
@@ -1,0 +1,330 @@
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+
+/// Errors returned when running a natural-language query.
+#[derive(Debug, Snafu)]
+pub enum NsqlError {
+    /// The request was rejected before being sent.
+    #[snafu(display("Invalid NSQL request: {message}"))]
+    InvalidRequest { message: String },
+
+    /// The runtime rejected the request.
+    #[snafu(display("NSQL request failed (HTTP {status_code}): {response_body}"))]
+    NsqlFailed {
+        /// HTTP status code returned by the server.
+        status_code: u16,
+        /// Response body from the server.
+        response_body: String,
+    },
+
+    /// HTTP transport error.
+    #[snafu(display("NSQL request failed: {message}"))]
+    HttpError { message: String },
+
+    /// Failed to parse the server response.
+    #[snafu(display("Failed to parse NSQL response: {message}"))]
+    ParseError { message: String },
+}
+
+/// Media type that makes the runtime return the generated SQL alongside the
+/// results. Without it `/v1/nsql` answers with a bare array of rows and the
+/// generated SQL is lost.
+pub(crate) const NSQL_JSON_MEDIA_TYPE: &str = "application/vnd.spiceai.nsql.v1+json";
+
+/// Media type that makes the runtime generate SQL without executing it.
+pub(crate) const NSQL_SQL_MEDIA_TYPE: &str = "application/sql";
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+/// A natural-language query against the runtime's `/v1/nsql` endpoint.
+///
+/// Only the query text is required. The runtime needs an LLM model configured
+/// in the Spicepod to translate it; when exactly one compatible model is
+/// configured, the model may be left unset and the runtime selects it.
+///
+/// ```
+/// use spiceai::NsqlRequest;
+///
+/// let request = NsqlRequest::new("top 5 customers by revenue")
+///     .with_datasets(["sales"])
+///     .with_sample_data(true);
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct NsqlRequest {
+    /// The question to answer, in natural language.
+    pub query: String,
+
+    /// The LLM used to generate SQL. When unset, the runtime uses the only
+    /// compatible model configured in the Spicepod, and reports an error if
+    /// there is not exactly one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+
+    /// Datasets to sample when building the model's context. This is a
+    /// sampling hint only — it does not restrict which tables the generated
+    /// query may reference. When empty, all datasets are used.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub datasets: Vec<String>,
+
+    /// Whether sample rows are included in the model's context. Improves
+    /// generation on ambiguous schemas, at the cost of sending data values to
+    /// the model.
+    #[serde(skip_serializing_if = "is_false")]
+    pub sample_data_enabled: bool,
+
+    /// A stable key forwarded to the model provider for prompt caching. Reuse
+    /// it across related requests to benefit from it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_key: Option<String>,
+}
+
+impl NsqlRequest {
+    /// Creates a request answering `query`.
+    #[must_use]
+    pub fn new(query: impl Into<String>) -> Self {
+        Self {
+            query: query.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Names the model used to generate SQL.
+    #[must_use]
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    /// Hints which datasets to sample when building the model's context.
+    #[must_use]
+    pub fn with_datasets<I, S>(mut self, datasets: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.datasets = datasets.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Includes sample rows in the model's context.
+    #[must_use]
+    pub fn with_sample_data(mut self, enabled: bool) -> Self {
+        self.sample_data_enabled = enabled;
+        self
+    }
+
+    /// Sets the prompt cache key forwarded to the model provider.
+    #[must_use]
+    pub fn with_prompt_cache_key(mut self, key: impl Into<String>) -> Self {
+        self.prompt_cache_key = Some(key.into());
+        self
+    }
+
+    /// Rejects requests the runtime would answer with a `400`, so the error
+    /// names the field to fix rather than reporting a status code.
+    pub(crate) fn validate(&self) -> Result<(), NsqlError> {
+        if self.query.trim().is_empty() {
+            return Err(NsqlError::InvalidRequest {
+                message: "query is required and must be a non-empty natural language query"
+                    .to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// One column of an [`NsqlResponse`].
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct NsqlField {
+    /// The column name.
+    #[serde(default)]
+    pub name: String,
+
+    /// The column's Arrow type, in the JSON encoding the runtime emits. Simple
+    /// types appear as a string (`"Utf8"`), parameterized ones as an object
+    /// (`{"Timestamp": ["Nanosecond", null]}`).
+    #[serde(default)]
+    pub data_type: serde_json::Value,
+
+    /// Whether the column admits nulls.
+    #[serde(default)]
+    pub nullable: bool,
+}
+
+/// The schema of the rows an NSQL query returned.
+///
+/// `fields` is empty when the generated query returned no rows — the runtime
+/// omits the schema body in that case.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+pub struct NsqlSchema {
+    /// The columns, in order.
+    #[serde(default)]
+    pub fields: Vec<NsqlField>,
+}
+
+/// The result of running a natural-language query.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+pub struct NsqlResponse {
+    /// The query the model generated. Worth logging: a surprising result is
+    /// usually a surprising query.
+    #[serde(default)]
+    pub sql: String,
+
+    /// The number of rows returned.
+    #[serde(default)]
+    pub row_count: usize,
+
+    /// The columns in `data`.
+    #[serde(default)]
+    pub schema: NsqlSchema,
+
+    /// The rows, each keyed by column name. Values are decoded from JSON, so
+    /// they carry JSON's types rather than the Arrow types named in `schema`.
+    /// Use [`crate::Client::nsql_generate_sql`] with [`crate::Client::query`]
+    /// when Arrow-typed results matter.
+    #[serde(default)]
+    pub data: Vec<serde_json::Map<String, serde_json::Value>>,
+}
+
+impl NsqlResponse {
+    /// Returns the number of rows in `data`.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Returns true when the generated query returned no rows.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+}
+
+impl IntoIterator for NsqlResponse {
+    type Item = serde_json::Map<String, serde_json::Value>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.into_iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn body(request: &NsqlRequest) -> serde_json::Value {
+        serde_json::to_value(request).expect("serialize nsql request")
+    }
+
+    #[test]
+    fn test_query_only_request_omits_optional_fields() {
+        assert_eq!(
+            body(&NsqlRequest::new("how many orders")),
+            serde_json::json!({"query": "how many orders"})
+        );
+    }
+
+    #[test]
+    fn test_full_request_serialization() {
+        let request = NsqlRequest::new("top 5 customers by revenue")
+            .with_model("nsql-model")
+            .with_datasets(["sales"])
+            .with_sample_data(true)
+            .with_prompt_cache_key("sales-dashboard");
+
+        assert_eq!(
+            body(&request),
+            serde_json::json!({
+                "query": "top 5 customers by revenue",
+                "model": "nsql-model",
+                "datasets": ["sales"],
+                "sample_data_enabled": true,
+                "prompt_cache_key": "sales-dashboard",
+            })
+        );
+    }
+
+    #[test]
+    fn test_defaults_omitted() {
+        // sample_data_enabled defaults to false server-side, so sending it
+        // adds nothing; an empty dataset list is a sampling hint of "all".
+        let request = NsqlRequest::new("how many orders")
+            .with_datasets(Vec::<String>::new())
+            .with_sample_data(false);
+        assert_eq!(
+            body(&request),
+            serde_json::json!({"query": "how many orders"})
+        );
+    }
+
+    #[test]
+    fn test_validate_rejects_empty_query() {
+        let err = NsqlRequest::new("   ")
+            .validate()
+            .expect_err("empty query should be rejected");
+        assert!(err.to_string().contains("non-empty"), "{err}");
+    }
+
+    #[test]
+    fn test_validate_accepts_minimal_request() {
+        NsqlRequest::new("how many orders")
+            .validate()
+            .expect("valid");
+    }
+
+    #[test]
+    fn test_response_deserialization() {
+        let response: NsqlResponse = serde_json::from_str(
+            r#"{
+                "row_count": 2,
+                "schema": {
+                    "fields": [
+                        {"name": "customer_id", "data_type": "Utf8", "nullable": false},
+                        {"name": "ts", "data_type": {"Timestamp": ["Nanosecond", null]}, "nullable": true}
+                    ]
+                },
+                "data": [
+                    {"customer_id": "12345", "ts": 1724716542},
+                    {"customer_id": "67890", "ts": 1724716543}
+                ],
+                "sql": "SELECT customer_id, ts FROM sales LIMIT 2"
+            }"#,
+        )
+        .expect("deserialize nsql response");
+
+        assert_eq!(response.sql, "SELECT customer_id, ts FROM sales LIMIT 2");
+        assert_eq!(response.row_count, 2);
+        assert_eq!(response.len(), 2);
+        assert!(!response.is_empty());
+        assert_eq!(response.data[0]["customer_id"], "12345");
+
+        assert_eq!(response.schema.fields.len(), 2);
+        assert_eq!(response.schema.fields[0].name, "customer_id");
+        // A simple Arrow type encodes as a string, a parameterized one as an
+        // object, which is why data_type stays a serde_json::Value.
+        assert_eq!(response.schema.fields[0].data_type, "Utf8");
+        assert_eq!(
+            response.schema.fields[1].data_type,
+            serde_json::json!({"Timestamp": ["Nanosecond", null]})
+        );
+        assert!(response.schema.fields[1].nullable);
+    }
+
+    #[test]
+    fn test_empty_result_set() {
+        // The runtime serializes schema as {} when the query returned no rows,
+        // so deserialization must not depend on a fields key being present.
+        let response: NsqlResponse = serde_json::from_str(
+            r#"{"row_count": 0, "schema": {}, "data": [], "sql": "SELECT 1 WHERE false"}"#,
+        )
+        .expect("deserialize");
+
+        assert!(response.is_empty());
+        assert!(response.schema.fields.is_empty());
+        assert_eq!(response.sql, "SELECT 1 WHERE false");
+        assert_eq!(response.into_iter().count(), 0);
+    }
+}

--- a/src/query.rs
+++ b/src/query.rs
@@ -35,6 +35,9 @@
 
 use crate::active_query::{ActiveQueryError, ActiveQueryList, CancelActiveQueryResponse};
 use crate::dataset::{DatasetError, DatasetRefreshRequest, DatasetRefreshResponse};
+use crate::nsql::{
+    NSQL_JSON_MEDIA_TYPE, NSQL_SQL_MEDIA_TYPE, NsqlError, NsqlRequest, NsqlResponse,
+};
 use crate::params::{QueryParameterError, QueryParameters};
 use crate::search::{SearchError, SearchRequest, SearchResponse};
 use arrow::array::RecordBatch;
@@ -961,6 +964,67 @@ impl QueryHttpClient {
         response.json().await.map_err(|e| SearchError::ParseError {
             message: e.to_string(),
         })
+    }
+
+    /// Posts `request` to `/v1/nsql` asking for `accept`, returning the body
+    /// when the runtime answered 200.
+    async fn nsql_body(&self, request: &NsqlRequest, accept: &str) -> Result<String, NsqlError> {
+        request.validate()?;
+
+        let url = format!("{}/v1/nsql", self.base_url);
+
+        let response = self
+            .add_auth(self.client.post(&url))
+            .header(reqwest::header::ACCEPT, accept)
+            .json(request)
+            .send()
+            .await
+            .map_err(|e| NsqlError::HttpError {
+                message: e.to_string(),
+            })?;
+
+        let status_code = response.status().as_u16();
+        let body = match response.text().await {
+            Ok(body) => body,
+            Err(e) => {
+                // On a 200 an unreadable body is a parse failure; on an error
+                // status the code is already known, so report why the
+                // explanation is missing rather than collapsing to an empty
+                // string.
+                if status_code == 200 {
+                    return Err(NsqlError::ParseError {
+                        message: e.to_string(),
+                    });
+                }
+                format!("<error body could not be read: {e}>")
+            }
+        };
+
+        if status_code != 200 {
+            // The runtime explains NSQL failures in a plain-text body — a
+            // missing or ambiguous model, or SQL that would not run. Surface
+            // it, not just the status code.
+            return Err(NsqlError::NsqlFailed {
+                status_code,
+                response_body: body.trim().to_string(),
+            });
+        }
+
+        Ok(body)
+    }
+
+    pub async fn nsql(&self, request: &NsqlRequest) -> Result<NsqlResponse, NsqlError> {
+        let body = self.nsql_body(request, NSQL_JSON_MEDIA_TYPE).await?;
+
+        serde_json::from_str(&body).map_err(|e| NsqlError::ParseError {
+            message: e.to_string(),
+        })
+    }
+
+    pub async fn nsql_generate_sql(&self, request: &NsqlRequest) -> Result<String, NsqlError> {
+        let body = self.nsql_body(request, NSQL_SQL_MEDIA_TYPE).await?;
+
+        Ok(body.trim().to_string())
     }
 
     /// List queries with optional status filter and limit.


### PR DESCRIPTION
## What

Adds `Client::nsql` and `Client::nsql_generate_sql`, wrapping the runtime's `/v1/nsql` text-to-SQL endpoint, plus the `NsqlRequest` / `NsqlResponse` types in a new `nsql` module.

## Why

Text-to-SQL is reachable from spice.js and from no other SDK. A Rust caller who wanted it had to hand-roll the HTTP request — including knowing to send `Accept: application/vnd.spiceai.nsql.v1+json`, without which the runtime falls back to a bare array of rows and the generated SQL is lost.

Two methods rather than one, because the generated SQL is useful on its own:

- `nsql` generates, runs, and returns the rows together with the SQL that produced them.
- `nsql_generate_sql` stops after generation. That lets a caller inspect or edit the query first, and — since `/v1/nsql` results arrive as decoded JSON, where Arrow types are flattened to JSON's — run it through `sql()` instead when Arrow types matter.

`NsqlRequest` follows the existing `SearchRequest` shape: `new()` plus `with_*` builders taking `mut self`. Errors are a typed `NsqlError` enum; a missing or ambiguous model is the most common failure and the runtime explains it in the response body, so that body is surfaced rather than collapsed into a status code.

Part of aligning capability across the SDKs; `/v1/search` and `/v1/status` landed here recently and NSQL was the remaining gap against the runtime's client-facing surface.

## Verification

- [x] `cargo build`, `cargo fmt --all --check`
- [x] `cargo clippy --all-features --all-targets` — no new warnings (the 5 remaining are pre-existing, in `tests/client_test.rs`)
- [x] `cargo test --lib` — 235 pass, including 12 new NSQL cases: request serialization and default-omission, response decoding with both a simple and a parameterized Arrow type, empty result set (the runtime sends `schema: {}`), and wiremock coverage asserting each media type, the surfaced error body, pre-send validation, and the missing-`http_url` path
- [x] `cargo test --doc` — 39 pass, including the two new README examples
- [ ] Integration tests — not run; the 7 `test_local_*` cases in `tests/client_test.rs` need `spice run` on the default ports and the `spice` CLI is not available in this environment.
